### PR TITLE
Fix backfill for french locale + Readme completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Track the carbon footprint of your Claude Code sessions.
 
 - Adds a live CO2 estimate to the Claude Code status line, next to the session cost
 - Persists each session to a local SQLite database
-- Backfills historical data from existing `~/.claude` transcripts
+- Backfills historical data from existing `~/.claude` transcripts (⚠️ default Claude configuration keeps only 30 days)
 - Generates shareable PNG report cards for LinkedIn
 - Exposes a `/claude-carbon:report` skill for a full emissions breakdown
 

--- a/scripts/backfill.sh
+++ b/scripts/backfill.sh
@@ -125,10 +125,10 @@ while IFS= read -r JSONL_FILE; do
   esac
 
   # Estimate cost (per million tokens)
-  COST_USD="$(echo "$TOTAL_INPUT $PRICE_IN $OUTPUT_TOKENS $PRICE_OUT" | awk '{printf "%.6f", ($1 * $2 + $3 * $4) / 1000000}')"
+  COST_USD="$(echo "$TOTAL_INPUT $PRICE_IN $OUTPUT_TOKENS $PRICE_OUT" | LC_ALL=C awk '{printf "%.6f", ($1 * $2 + $3 * $4) / 1000000}')"
 
   # Calculate CO2
-  CO2_G="$(echo "$TOTAL_INPUT $FACTOR_IN $OUTPUT_TOKENS $FACTOR_OUT" | awk '{printf "%.4f", ($1 * $2 + $3 * $4) / 1000000}')"
+  CO2_G="$(echo "$TOTAL_INPUT $FACTOR_IN $OUTPUT_TOKENS $FACTOR_OUT" | LC_ALL=C awk '{printf "%.4f", ($1 * $2 + $3 * $4) / 1000000}')"
 
   # Sanitize strings for SQL (escape single quotes)
   PROJECT="${PROJECT//\'/\'\'}"


### PR DESCRIPTION
The french locale uses commas as decimal separators, so awk outputs 0,904377 instead of 0.904377, breaking the SQL statement.
Fix: force LC_ALL=C on the awk calls in backfill.sh.

⚠️ default Claude configuration keeps only 30 days