### PR TITLE
fix: locale-safe arithmetic, Stop hook transcript parsing, setup.sh PLUGIN_DIR

### DIFF
--- a/scripts/generate-report.sh
+++ b/scripts/generate-report.sh
@@ -84,28 +84,33 @@ TOTAL_TOKENS_RAW="$(sqlite3 "$DB_PATH" "SELECT COALESCE(SUM(input_tokens), 0) + 
 # ── Format values ───────────────────────────────────────────
 format_co2() {
   local grams="$1"
-  if (( $(echo "$grams >= 1000" | bc -l) )); then
-    echo "$(echo "$grams" | awk '{printf "%.1f", $1/1000}') kg"
+  if (( $(echo "$grams >= 1000" | LC_ALL=C bc -l) )); then
+    echo "$(echo "$grams" | LC_ALL=C awk '{printf "%.1f", $1/1000}') kg"
   else
-    echo "$(echo "$grams" | awk '{printf "%.0f", $1}') g"
+    echo "$(echo "$grams" | LC_ALL=C awk '{printf "%.0f", $1}') g"
   fi
 }
 
 read -r TOTAL_CO2_VALUE TOTAL_CO2_UNIT <<< "$(format_co2 "$TOTAL_CO2_RAW")"
-TOTAL_COST="$(echo "$TOTAL_COST_RAW" | awk '{printf "%.0f", $1}')"
+TOTAL_COST="$(echo "$TOTAL_COST_RAW" | LC_ALL=C awk '{printf "%.0f", $1}')"
 FIRST_DATE="$(echo "$FIRST_DATE_RAW" | cut -c1-10)"
-EQUIV_KM="$(echo "$TOTAL_CO2_RAW" | awk '{printf "%.1f", $1/120}')"
+EQUIV_KM="$(echo "$TOTAL_CO2_RAW" | LC_ALL=C awk '{printf "%.1f", $1/120}')"
 
 # Format tokens (M)
-TOTAL_TOKENS="$(echo "$TOTAL_TOKENS_RAW" | awk '{printf "%.0f", $1/1000000}')"
+TOTAL_TOKENS="$(echo "$TOTAL_TOKENS_RAW" | LC_ALL=C awk '{printf "%.0f", $1/1000000}')"
 
 # Projection annuelle (fourchette)
 # Use actual first session date, not --since filter
 ACTUAL_FIRST="$(echo "$FIRST_DATE" | cut -c1-10)"
-DAYS_ELAPSED="$(( ( $(date +%s) - $(date -j -f "%Y-%m-%d" "${ACTUAL_FIRST}" +%s 2>/dev/null || date -d "${ACTUAL_FIRST}" +%s 2>/dev/null) ) / 86400 ))"
+_FIRST_EPOCH="$(date -j -f "%Y-%m-%d" "${ACTUAL_FIRST}" +%s 2>/dev/null || date -d "${ACTUAL_FIRST}" +%s 2>/dev/null || echo "")"
+if [ -n "$_FIRST_EPOCH" ]; then
+  DAYS_ELAPSED="$(( ( $(date +%s) - _FIRST_EPOCH ) / 86400 ))"
+else
+  DAYS_ELAPSED=0
+fi
 if [ "$DAYS_ELAPSED" -gt 0 ]; then
   # Linear: average daily rate extrapolated (in tCO2 with 1 decimal)
-  PROJ_LINEAR="$(echo "$TOTAL_CO2_RAW $DAYS_ELAPSED" | awk '{printf "%.1f", ($1 / $2) * 365 / 1000000}')"
+  PROJ_LINEAR="$(echo "$TOTAL_CO2_RAW $DAYS_ELAPSED" | LC_ALL=C awk '{printf "%.1f", ($1 / $2) * 365 / 1000000}')"
 
   # Trend: last 30 days daily rate extrapolated
   LAST_MONTH_DATA="$(sqlite3 "$DB_PATH" "SELECT SUM(co2_grams), MIN(started_at), MAX(started_at) FROM sessions ${WHERE} AND started_at >= date('now', '-30 days');" | tr '|' ' ')"
@@ -114,7 +119,7 @@ if [ "$DAYS_ELAPSED" -gt 0 ]; then
   LAST_MONTH_END="$(echo "$LAST_MONTH_DATA" | awk '{print $3}' | cut -c1-10)"
   LAST_MONTH_DAYS="$(( ( $(date -j -f "%Y-%m-%d" "${LAST_MONTH_END}" +%s 2>/dev/null || date -d "${LAST_MONTH_END}" +%s 2>/dev/null) - $(date -j -f "%Y-%m-%d" "${LAST_MONTH_START}" +%s 2>/dev/null || date -d "${LAST_MONTH_START}" +%s 2>/dev/null) ) / 86400 ))"
   if [ "$LAST_MONTH_DAYS" -gt 0 ]; then
-    PROJ_TREND="$(echo "$LAST_MONTH_CO2 $LAST_MONTH_DAYS" | awk '{printf "%.1f", ($1 / $2) * 365 / 1000000}')"
+    PROJ_TREND="$(echo "$LAST_MONTH_CO2 $LAST_MONTH_DAYS" | LC_ALL=C awk '{printf "%.1f", ($1 / $2) * 365 / 1000000}')"
   else
     PROJ_TREND="$PROJ_LINEAR"
   fi
@@ -142,7 +147,7 @@ while IFS='|' read -r month_key month_co2; do
   month_num_clean="$(echo "$month_num" | sed 's/^0//')"
   month_label="$(echo "$MONTH_NAMES" | awk -v n="$month_num_clean" '{print $n}')"
   if [ "$MAX_MONTH_CO2" -gt 0 ] 2>/dev/null; then
-    pct="$(echo "$month_co2 $MAX_MONTH_CO2" | awk '{printf "%.0f", ($1/$2)*100}')"
+    pct="$(echo "$month_co2 $MAX_MONTH_CO2" | LC_ALL=C awk '{printf "%.0f", ($1/$2)*100}')"
   else
     pct="10"
   fi
@@ -204,15 +209,15 @@ inject_common() {
 
 # Generate FR templates
 SINCE_LABEL="$SINCE_LABEL_FR"
-TMP_SUMMARY_FR="$(mktemp /tmp/claude-carbon-summary-fr-XXXXXX.html)"
-TMP_DETAILED_FR="$(mktemp /tmp/claude-carbon-detailed-fr-XXXXXX.html)"
+_t=$(mktemp /tmp/claude-carbon-summary-fr-XXXXXX); TMP_SUMMARY_FR="${_t}.html"; mv "$_t" "$TMP_SUMMARY_FR"
+_t=$(mktemp /tmp/claude-carbon-detailed-fr-XXXXXX); TMP_DETAILED_FR="${_t}.html"; mv "$_t" "$TMP_DETAILED_FR"
 inject_common "$TEMPLATE_DIR/report-summary.html" "$TMP_SUMMARY_FR"
 inject_common "$TEMPLATE_DIR/report-detailed.html" "$TMP_DETAILED_FR"
 
 # Generate EN templates
 SINCE_LABEL="$SINCE_LABEL_EN"
-TMP_SUMMARY_EN="$(mktemp /tmp/claude-carbon-summary-en-XXXXXX.html)"
-TMP_DETAILED_EN="$(mktemp /tmp/claude-carbon-detailed-en-XXXXXX.html)"
+_t=$(mktemp /tmp/claude-carbon-summary-en-XXXXXX); TMP_SUMMARY_EN="${_t}.html"; mv "$_t" "$TMP_SUMMARY_EN"
+_t=$(mktemp /tmp/claude-carbon-detailed-en-XXXXXX); TMP_DETAILED_EN="${_t}.html"; mv "$_t" "$TMP_DETAILED_EN"
 inject_common "$TEMPLATE_DIR/report-summary-en.html" "$TMP_SUMMARY_EN"
 inject_common "$TEMPLATE_DIR/report-detailed-en.html" "$TMP_DETAILED_EN"
 
@@ -220,7 +225,7 @@ inject_common "$TEMPLATE_DIR/report-detailed-en.html" "$TMP_DETAILED_EN"
 TMP_SUMMARY="$TMP_SUMMARY_FR"
 
 # Inject monthly bars via python (bash/sed can't handle % in style attrs)
-TMP_MONTHLY="$(mktemp /tmp/claude-carbon-monthly-XXXXXX.txt)"
+_t=$(mktemp /tmp/claude-carbon-monthly-XXXXXX); TMP_MONTHLY="${_t}.txt"; mv "$_t" "$TMP_MONTHLY"
 echo "$MONTHLY_DATA" > "$TMP_MONTHLY"
 
 export TMP_SUMMARY TMP_MONTHLY
@@ -292,7 +297,9 @@ rm -f "$TMP_MONTHLY"
 PW_PATH="$(node -e "try { console.log(require.resolve('playwright-core').replace(/\/index\.js$/, '')); } catch(e) { process.exit(1); }" 2>/dev/null)" || true
 
 if [ -z "$PW_PATH" ]; then
+  _npm_global_root="$(npm root -g 2>/dev/null || true)"
   for candidate in \
+    "${_npm_global_root}/playwright-core" \
     "${HOME}/node_modules/playwright-core" \
     "${HOME}/claude cowork/node_modules/playwright-core" \
     "/opt/homebrew/lib/node_modules/playwright-core"; do
@@ -306,7 +313,7 @@ fi
 if [ -z "$PW_PATH" ]; then
   echo "Error: playwright-core not found." >&2
   echo "Install: npm install -g playwright-core && npx playwright install chromium" >&2
-  rm -f "$TMP_SUMMARY" "$TMP_DETAILED"
+  rm -f "$TMP_SUMMARY_FR" "$TMP_SUMMARY_EN"
   exit 1
 fi
 

--- a/scripts/parse-transcript.py
+++ b/scripts/parse-transcript.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+# parse-transcript.py — Parses a Claude JSONL transcript and outputs:
+# model|effective_input_tokens|output_tokens|first_timestamp|last_timestamp
+import sys
+import json
+
+if len(sys.argv) < 2:
+    sys.exit(1)
+
+path = sys.argv[1]
+total_in = total_out = total_cache_create = total_cache_read = 0
+model = ""
+timestamps = []
+
+with open(path) as f:
+    for line in f:
+        try:
+            d = json.loads(line)
+        except Exception:
+            continue
+        msg = d.get("message", {})
+        usage = msg.get("usage", {})
+        if usage:
+            total_in += usage.get("input_tokens", 0)
+            total_out += usage.get("output_tokens", 0)
+            total_cache_create += usage.get("cache_creation_input_tokens", 0)
+            total_cache_read += usage.get("cache_read_input_tokens", 0)
+            if msg.get("model"):
+                model = msg["model"]
+        ts = d.get("timestamp")
+        if ts:
+            timestamps.append(ts)
+
+first_ts = min(timestamps) if timestamps else ""
+last_ts = max(timestamps) if timestamps else ""
+effective_in = total_in + total_cache_create + total_cache_read
+
+print(f"{model}|{effective_in}|{total_out}|{first_ts}|{last_ts}")

--- a/scripts/persist-session.sh
+++ b/scripts/persist-session.sh
@@ -1,34 +1,41 @@
 #!/usr/bin/env bash
 # persist-session.sh — Stop hook: persist session CO2 data to SQLite DB.
-# Reads JSON from stdin (same format as statusline). Never fails, never prints output.
+# Reads Stop hook JSON from stdin, parses transcript JSONL for token counts.
 # Intentionally no set -euo pipefail: this hook must exit 0 silently in all cases.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FACTORS_FILE="${SCRIPT_DIR}/../data/factors.json"
 DB_PATH="${HOME}/.claude/claude-carbon/carbon.db"
 
-# Exit silently if DB doesn't exist (plugin not set up yet)
+# Exit silently if DB doesn't exist
 [ -f "$DB_PATH" ] || exit 0
 
 # Read stdin
 INPUT="$(cat 2>/dev/null)" || exit 0
-
-# Exit silently if no input
 [ -n "$INPUT" ] || exit 0
 
-# Extract session_id — exit silently if missing
+# Extract session_id and transcript_path from Stop hook JSON
 SESSION_ID="$(echo "$INPUT" | jq -r '.session_id // ""' 2>/dev/null)" || exit 0
 [ -n "$SESSION_ID" ] || exit 0
 
-# Extract remaining fields
-MODEL_ID="$(echo "$INPUT" | jq -r '.model.id // ""' 2>/dev/null)" || exit 0
-CURRENT_DIR="$(echo "$INPUT" | jq -r '.workspace.current_dir // ""' 2>/dev/null)" || exit 0
-COST_USD="$(echo "$INPUT" | jq -r '.cost.total_cost_usd // 0' 2>/dev/null)" || exit 0
-INPUT_TOKENS="$(echo "$INPUT" | jq -r '.context_window.total_input_tokens // 0' 2>/dev/null)" || exit 0
-OUTPUT_TOKENS="$(echo "$INPUT" | jq -r '.context_window.total_output_tokens // 0' 2>/dev/null)" || exit 0
+TRANSCRIPT_PATH="$(echo "$INPUT" | jq -r '.transcript_path // ""' 2>/dev/null)" || exit 0
+[ -f "$TRANSCRIPT_PATH" ] || exit 0
 
-# Project name = last path segment
-PROJECT="$(basename "$CURRENT_DIR" 2>/dev/null)" || PROJECT="unknown"
+CWD="$(echo "$INPUT" | jq -r '.cwd // ""' 2>/dev/null)" || exit 0
+PROJECT="$(basename "$CWD" 2>/dev/null)" || PROJECT="unknown"
+
+# Parse transcript JSONL to extract totals
+PARSED="$(python3 "${SCRIPT_DIR}/parse-transcript.py" "$TRANSCRIPT_PATH" 2>/dev/null)" || exit 0
+
+[ -n "$PARSED" ] || exit 0
+
+MODEL_ID="$(echo "$PARSED" | cut -d'|' -f1)"
+INPUT_TOKENS="$(echo "$PARSED" | cut -d'|' -f2)"
+OUTPUT_TOKENS="$(echo "$PARSED" | cut -d'|' -f3)"
+STARTED_AT="$(echo "$PARSED" | cut -d'|' -f4)"
+ENDED_AT="$(echo "$PARSED" | cut -d'|' -f5)"
+
+[ -n "$INPUT_TOKENS" ] || exit 0
 
 # Resolve model family
 MODEL_FAMILY="sonnet"
@@ -42,19 +49,19 @@ fi
 FACTOR_IN="$(jq -r ".models.${MODEL_FAMILY}.input" "$FACTORS_FILE" 2>/dev/null)" || exit 0
 FACTOR_OUT="$(jq -r ".models.${MODEL_FAMILY}.output" "$FACTORS_FILE" 2>/dev/null)" || exit 0
 
-# Calculate CO2
-CO2_G="$(echo "$INPUT_TOKENS $FACTOR_IN $OUTPUT_TOKENS $FACTOR_OUT" | awk '{printf "%.4f", ($1 * $2 + $3 * $4) / 1000000}' 2>/dev/null)" || exit 0
+# Calculate CO2 in grams
+CO2_G="$(echo "$INPUT_TOKENS $FACTOR_IN $OUTPUT_TOKENS $FACTOR_OUT" | LC_ALL=C awk '{printf "%.4f", ($1 * $2 + $3 * $4) / 1000000}' 2>/dev/null)" || exit 0
 
-# Current timestamp
+# Fallback timestamp
 NOW="$(date -u +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null)" || NOW=""
+[ -n "$STARTED_AT" ] || STARTED_AT="$NOW"
+[ -n "$ENDED_AT" ] || ENDED_AT="$NOW"
 
-# Sanitize strings for SQL (escape single quotes)
+# Sanitize strings for SQL
 SESSION_ID="${SESSION_ID//\'/\'\'}"
 PROJECT="${PROJECT//\'/\'\'}"
 MODEL_ID="${MODEL_ID//\'/\'\'}"
-NOW="${NOW//\'/\'\'}"
 
-# INSERT OR REPLACE into sessions (source='live')
-sqlite3 "$DB_PATH" "INSERT OR REPLACE INTO sessions (session_id, project, model, input_tokens, output_tokens, cost_usd, co2_grams, started_at, ended_at, source) VALUES ('${SESSION_ID}', '${PROJECT}', '${MODEL_ID}', ${INPUT_TOKENS}, ${OUTPUT_TOKENS}, ${COST_USD}, ${CO2_G}, COALESCE((SELECT started_at FROM sessions WHERE session_id='${SESSION_ID}'), '${NOW}'), '${NOW}', 'live');" 2>/dev/null || true
+sqlite3 "$DB_PATH" "INSERT OR REPLACE INTO sessions (session_id, project, model, input_tokens, output_tokens, cost_usd, co2_grams, started_at, ended_at, source) VALUES ('${SESSION_ID}', '${PROJECT}', '${MODEL_ID}', ${INPUT_TOKENS}, ${OUTPUT_TOKENS}, 0, ${CO2_G}, '${STARTED_AT}', '${ENDED_AT}', 'live');" 2>/dev/null || true
 
 exit 0

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 # setup.sh — Initialize claude-carbon: check deps, create DB, backfill history, show summary.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_DIR="$(dirname "$SCRIPT_DIR")"
 DB_DIR="${HOME}/.claude/claude-carbon"
 DB_PATH="${DB_DIR}/carbon.db"
 

--- a/scripts/statusline.sh
+++ b/scripts/statusline.sh
@@ -35,17 +35,17 @@ FACTOR_IN="$(jq -r ".models.${MODEL_FAMILY}.input" "$FACTORS_FILE")"
 FACTOR_OUT="$(jq -r ".models.${MODEL_FAMILY}.output" "$FACTORS_FILE")"
 
 # Calculate CO2 in grams: (input * factor_in + output * factor_out) / 1_000_000
-CO2_G="$(echo "$INPUT_TOKENS $FACTOR_IN $OUTPUT_TOKENS $FACTOR_OUT" | awk '{printf "%.0f", ($1 * $2 + $3 * $4) / 1000000}')"
+CO2_G="$(echo "$INPUT_TOKENS $FACTOR_IN $OUTPUT_TOKENS $FACTOR_OUT" | LC_ALL=C awk '{printf "%.0f", ($1 * $2 + $3 * $4) / 1000000}')"
 
 # Format CO2 with adaptive unit
 if [ "$CO2_G" -ge 1000 ] 2>/dev/null; then
-  CO2_DISPLAY="$(echo "$CO2_G" | awk '{printf "%.1fkg", $1/1000}') CO₂"
+  CO2_DISPLAY="$(echo "$CO2_G" | LC_ALL=C awk '{printf "%.1fkg", $1/1000}') CO₂"
 else
   CO2_DISPLAY="${CO2_G}g CO₂"
 fi
 
 # Round cost to 2 decimals
-COST_DISPLAY="$(echo "$COST_USD" | awk '{printf "%.2f", $1}')"
+COST_DISPLAY="$(echo "$COST_USD" | LC_ALL=C awk '{printf "%.2f", $1}')"
 
 # Build progress bar (10 blocks)
 FILLED=$(( USED_PCT * 10 / 100 ))


### PR DESCRIPTION
## Summary

Four bugs found and fixed while running the scripts on a French macOS system.

### 1. `LC_ALL=C` on all `awk`/`bc` calls

On non-English locales (French, German, etc.), `awk` uses a comma as the decimal separator, producing values like `756,0039` instead of `756.0039`. This is invalid for SQLite and shell arithmetic, causing **silent zero values in all reports and the statusline**.

All floating-point `awk` and `bc` calls in `generate-report.sh`, `persist-session.sh`, and `statusline.sh` are now prefixed with `LC_ALL=C`.

### 2. Stop hook now reads the transcript JSONL

The Claude Code `Stop` hook sends minimal JSON to stdin — only `session_id`, `transcript_path`, `cwd`, etc. The previous `persist-session.sh` expected `model.id`, `context_window.total_input_tokens`, and `cost.total_cost_usd`, which are **only available in the statusline hook**, not the Stop hook.

Result: every session was persisted with 0 tokens and 0g CO₂.

**Fix:** parse the transcript JSONL at `transcript_path` and sum all `usage` entries across messages. The parsing logic lives in a new `scripts/parse-transcript.py` (a heredoc inside a `$()` subshell is not supported in bash).

### 3. `setup.sh`: derive `PLUGIN_DIR` dynamically

`PLUGIN_DIR` was used in the generated `settings.json` snippet but never defined, producing empty paths. Now derived from `SCRIPT_DIR` so it works regardless of where the repo is cloned.

### 4. `generate-report.sh`: misc fixes

- **`mktemp` with `.html` suffix** fails on macOS — the suffix after the `X`s is not replaced. Now creates a file without suffix then renames it.
- **`TMP_DETAILED` unbound variable** — this variable was referenced but never defined; replaced with the correct `TMP_SUMMARY_FR`/`TMP_SUMMARY_EN`.
- **`DAYS_ELAPSED` arithmetic** — protected against an empty `ACTUAL_FIRST` date (e.g. empty DB) which caused a syntax error.
- **Playwright detection** — now uses `npm root -g` to find global installs, covering `nvm`-managed Node environments.

## Test plan

- [ ] Run `bash scripts/generate-report.sh --all` on a non-English locale (e.g. `LANG=fr_FR.UTF-8`) and verify CO₂ values are non-zero
- [ ] Start a Claude Code session, `/exit`, and verify a row with correct token counts is inserted in `carbon.db`
- [ ] Run `bash scripts/setup.sh` and verify the displayed `settings.json` snippet contains correct paths
- [ ] Verify `mktemp` no longer errors on macOS with existing `/tmp/claude-carbon-*.html` files