### PR TITLE
fix: inject monthly bars into EN summary using explicit temp path

### DIFF
--- a/scripts/generate-report.sh
+++ b/scripts/generate-report.sh
@@ -232,12 +232,13 @@ TMP_SUMMARY="$TMP_SUMMARY_FR"
 _t=$(mktemp /tmp/claude-carbon-monthly-XXXXXX); TMP_MONTHLY="${_t}.txt"; mv "$_t" "$TMP_MONTHLY"
 echo "$MONTHLY_DATA" > "$TMP_MONTHLY"
 
-export TMP_SUMMARY TMP_MONTHLY
+export TMP_SUMMARY TMP_SUMMARY_EN TMP_MONTHLY
 python3 << 'PYEOF'
 import sys, os
 
 months_fr = ["Jan", "Fév", "Mar", "Avr", "Mai", "Jun", "Jul", "Aoû", "Sep", "Oct", "Nov", "Déc"]
 summary_file = os.environ["TMP_SUMMARY"]
+summary_file_en = os.environ.get("TMP_SUMMARY_EN", "")
 monthly_file = os.environ["TMP_MONTHLY"]
 
 # Parse monthly data
@@ -271,8 +272,8 @@ for label, co2, display in rows:
     )
 
 # Inject into all summary files
-for sf in [summary_file, summary_file.replace("-fr-", "-en-")]:
-    if os.path.exists(sf):
+for sf in [summary_file, summary_file_en]:
+    if sf and os.path.exists(sf):
         with open(sf) as f:
             content = f.read()
         content = content.replace("{{MONTHLY_BARS}}", bars_html)

--- a/scripts/generate-report.sh
+++ b/scripts/generate-report.sh
@@ -238,7 +238,7 @@ import sys, os
 
 months_fr = ["Jan", "Fév", "Mar", "Avr", "Mai", "Jun", "Jul", "Aoû", "Sep", "Oct", "Nov", "Déc"]
 summary_file = os.environ["TMP_SUMMARY"]
-summary_file_en = os.environ.get("TMP_SUMMARY_EN", "")
+summary_file_en = os.environ["TMP_SUMMARY_EN"]
 monthly_file = os.environ["TMP_MONTHLY"]
 
 # Parse monthly data


### PR DESCRIPTION
The bug was that `mktemp` generates independent random suffixes for each temp file (e.g. `summary-fr-ABC123.html` and `summary-en-XYZ789.html`), so replacing `-fr-` with `-en-` in the FR path produced a path that didn't exist. Now `TMP_SUMMARY_EN` is exported and passed directly into the Python block.

BEFORE:

<img width="238" height="131" alt="image" src="https://github.com/user-attachments/assets/877a54a9-a21a-4eea-9b1b-69b67655a64a" />

AFTER:

<img width="371" height="121" alt="image" src="https://github.com/user-attachments/assets/fba2f711-bf27-4556-8348-f7b6f85c19dd" />
