### PR TITLE
fix: dedup tokens, current pricing, cache_read energy + durable raw-t…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 *.db-journal
 exports/
 docs/private/
+.DS_Store
+.playwright-mcp/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## 2026-06-05
+
+### fix: deduplicate tokens, correct pricing, and count cache_read energy
+
+Three correctness fixes to token accounting in `backfill.sh` and `persist-session.sh`, validated against ccusage on the same JSONL:
+
+- **Deduplication.** `aggregate_jsonl` now dedups assistant messages by `(message.id, requestId)` keeping the last occurrence, before summing. Resumed/compacted sessions replay prior messages within a file and streaming writes the same message repeatedly; 55% of assistant lines on observed data are replays, so the previous raw sum over-counted tokens ~3x. The duplication is entirely within-file, so per-file dedup is sufficient.
+- **Pricing.** Replaced the hardcoded $15/$75 (retired Opus 4.0/4.1 rate) with current Anthropic list pricing: Opus 4.6+ $5/$25, Sonnet $3/$15, Haiku $1/$5. Cost now also counts cache_write at 1.25x input and cache_read at 0.1x input. On deduplicated data `cost_usd` reconciles to within a few percent of ccusage.
+- **Cache read energy.** Cache reads (90%+ of token volume) are no longer excluded from CO2. They now count at `cache_read_factor` (default 0.08) of the input factor, an engineering estimate of the decode-phase KV re-read residual, documented in METHODOLOGY.md and `data/factors.json`. This is not the 0.1x billing ratio (a price, not energy).
+
+Schema gains a `cache_read_tokens` column (idempotent `ALTER TABLE` migration in setup/backfill/persist; new installs get it in `CREATE TABLE`). `CLAUDE_CARBON_DB` env var added to override the DB path for testing. Existing rows keep their old values until a re-backfill; new live sessions use the corrected methodology immediately.
+
+### feat: durable raw-token storage + recompute, surviving the 30-day JSONL purge
+
+Make the DB self-sufficient so derived metrics survive Anthropic's ~30-day transcript purge and any future methodology change, without ever needing the JSONL again.
+
+- **Raw tokens stored, not just derived numbers.** Added `cache_creation_tokens` and `methodology_version` columns. Rows now carry the full breakdown (regular input = `input_tokens - cache_creation_tokens`, cache write, cache read, output), so cost and CO2 become pure functions of stored tokens + config.
+- **`recompute.sh`** (new). Re-derives `cost_usd` and `co2_grams` for all `methodology_version >= 2` rows from `data/factors.json` + `data/prices.json`, no JSONL. Run it after any price/factor change. Mixed-model sessions recompute at the dominant model (small approximation; the insert is per-subagent accurate). `CLAUDE_CARBON_FACTORS` / `CLAUDE_CARBON_PRICES` env overrides for testing.
+- **`data/prices.json`** (new). Pricing moved out of the scripts into config (Opus $5/$25, Sonnet $3/$15, Haiku $1/$5; cache write 1.25x, cache read 0.1x). A future price change is one edit + `recompute.sh`, not a code change in three scripts.
+- **`safety-rescan.sh`** (new) + `SessionStart` hook. Throttled (once/day), backgrounded `backfill.sh` re-run that catches sessions the `Stop` hook missed, while their transcript is still on disk.
+
+Verified end-to-end on a temp DB: backfill stores the raw breakdown; recompute reproduces totals from tokens alone (~$2,667 / 230 kg, matching ccusage); changing the cache_read_factor moves CO2 only; changing a price moves cost only.
+
 ## 2026-04-21
 
 ### fix: restore reset time display when stdin passes epoch

--- a/METHODOLOGY.md
+++ b/METHODOLOGY.md
@@ -14,10 +14,14 @@ The paper measures inference energy consumption on AWS infrastructure for a rang
 ## Formula
 
 ```
-session_co2_grams = (input_tokens * input_factor + output_tokens * output_factor) / 1_000_000
+session_co2_grams = (
+    (input_tokens + cache_write_tokens) * input_factor
+  + cache_read_tokens * (input_factor * cache_read_factor)
+  + output_tokens * output_factor
+) / 1_000_000
 ```
 
-Factors are in gCO2e per million tokens.
+Factors are in gCO2e per million tokens. `cache_write_tokens` (`cache_creation_input_tokens`) are a full prefill, so they count at the input factor. `cache_read_tokens` count at a reduced `cache_read_factor` (default 0.08) of the input factor (see Cache read energy below).
 
 ## Infrastructure parameters
 
@@ -48,11 +52,39 @@ The Jegham paper measured Sonnet-class models directly. Opus and Haiku factors a
 
 These are order-of-magnitude estimates. Actual values depend on Anthropic's specific hardware configuration and batching strategies, which are not publicly available.
 
+## Token counting and deduplication
+
+Token counts come from parsing the JSONL transcripts (`message.usage`). Assistant messages are deduplicated by `(message.id, requestId)`, keeping the last occurrence, before summing. This matters because resumed and compacted sessions replay earlier messages within the same file, and streaming writes the same message multiple times with a growing `output_tokens`. Without dedup the raw line sum over-counts by roughly 3x (on observed data, 55% of assistant lines are replays). This matches the deduplication ccusage performs.
+
+## Surviving the 30-day transcript purge
+
+Claude Code purges JSONL transcripts after about 30 days, so the SQLite DB is the only durable record. Two design choices follow:
+
+1. **Capture before purge.** The `Stop` hook (`persist-session.sh`) writes each session to the DB when it ends, while the JSONL still exists. A throttled `SessionStart` hook (`safety-rescan.sh`) re-runs `backfill.sh` once a day in the background to catch any session the `Stop` hook missed (crash, kill, hook disabled), as long as its transcript is still within the 30-day window. The only unavoidable gaps are history older than the install date and downtime longer than 30 days.
+
+2. **Store raw tokens, derive on demand.** Each row stores the raw token breakdown: `input_tokens` (regular input + cache write), `cache_creation_tokens` (cache write), `cache_read_tokens`, and `output_tokens`. Cost and CO2 are pure functions of these counts plus `data/factors.json` and `data/prices.json`, so they can be regenerated at any time with `recompute.sh` without re-reading the (purged) JSONL. When Anthropic changes a price, or a factor is revised, edit the config and run `recompute.sh`. Rows are tagged `methodology_version`; only version >= 2 carries the full raw-token breakdown, so older rows captured before this change are left untouched as legacy.
+
+`recompute.sh` recomputes a mixed-model session (subagents on a different model) at the row's dominant model, a small approximation; the original insert is model-accurate per subagent.
+
+## Cache read energy
+
+A `cache_read` token is a previously-processed context token whose key/value tensors are reused, so its prefill compute is skipped. It is not free in energy: during decode, every generated token re-reads the entire KV cache from HBM, including the cached tokens (GreenCache, SIGMETRICS: "caching does not reduce computation in the decode phase"). So the energy of a cached token is the decode-phase KV-read residual that survives caching.
+
+No study directly measures the cache_read-to-input energy ratio. The default `cache_read_factor` of **0.08** (defensible range 0.05-0.15, hard bound 0-0.20) is an engineering estimate derived from adjacent measurements: prefill is ≤ 3.4% of total inference energy for generation workloads (Solovyeva & Castor), a larger KV cache amplifies per-token decode energy by 1.3-51.8%, and per-token energy rises ~3x from 2K to 10K context (TokenPowerBench, H100). The factor is workload-dependent and grows with context length; a flat constant understates very long reused prefixes.
+
+This factor is **not** Anthropic's 0.1x cache_read billing ratio. That is a price, not an energy measurement (OpenAI prices the same mechanism at 0.5x). Setting `cache_read_factor` to 0 is a defensible lower bound but treats a reused 100K-token system prompt as carbon-free, which understates a real memory-bandwidth cost.
+
+Sources: GreenCache (arXiv:2505.23970), TokenPowerBench (arXiv:2512.03024), Solovyeva & Castor (arXiv:2602.05712), From Prompts to Power (arXiv:2511.05597).
+
+## Cost estimate
+
+The `cost_usd` column is the theoretical API list value of the usage (what it would cost on pay-as-you-go), not the subscription price actually paid. It uses current Anthropic list pricing per million tokens: Opus 4.6+ at $5 input / $25 output (not the retired $15/$75 of Opus 4.0/4.1), Sonnet at $3/$15, Haiku at $1/$5. Cache write is billed at 1.25x input and cache read at 0.1x input. On deduplicated data this reconciles to within a few percent of ccusage.
+
 ## Limitations
 
 - Order of magnitude only. Do not use these numbers for regulatory reporting or lifecycle assessments.
 - Inference only. Training costs, hardware manufacturing, and cooling water are not included.
-- Cache read tokens excluded from reports. Only `input_tokens` and `cache_creation_input_tokens` are counted in backfill and persist-session (JSONL parsing). Cache reads (90%+ of tokens in Claude Code) consume negligible energy and are ignored.
+- Cache read energy is a derived estimate, not a measurement (see Cache read energy below). Cache reads are 90%+ of tokens in Claude Code, so the chosen factor (default 0.08) is the single biggest lever on the headline number.
 - Status line is approximate. Claude Code does not expose `cache_read_input_tokens` separately in the statusline hook JSON, and parsing JSONL incrementally at each turn would be too slow. The live display uses `context_window.total_input_tokens` (current context size, includes cache reads, no subagents). This is not used in reports.
 - Grid-average, not real-time. The CIF is a static US grid average. Actual emissions depend on Anthropic's datacenter location, energy mix, and time of day.
 - No multi-region awareness. AWS runs inference in multiple regions with different grid intensities.

--- a/README.md
+++ b/README.md
@@ -113,17 +113,25 @@ Restart Claude Code.
 
 **Three data paths, two levels of accuracy:**
 
-| Script               | Trigger                 | Data source           | Subagents    | Cache reads | Accuracy      |
-| -------------------- | ----------------------- | --------------------- | ------------ | ----------- | ------------- |
-| `backfill.sh`        | Manual / setup          | JSONL files           | Included     | Excluded    | Best estimate |
-| `persist-session.sh` | Stop hook (session end) | JSONL files           | Included     | Excluded    | Best estimate |
-| `statusline.sh`      | Every turn (live)       | `context_window` JSON | Not included | Included\*  | Approximate   |
+| Script               | Trigger                 | Data source           | Subagents    | Cache reads         | Accuracy      |
+| -------------------- | ----------------------- | --------------------- | ------------ | ------------------- | ------------- |
+| `backfill.sh`        | Manual / setup          | JSONL files           | Included     | Counted (8% energy) | Best estimate |
+| `persist-session.sh` | Stop hook (session end) | JSONL files           | Included     | Counted (8% energy) | Best estimate |
+| `statusline.sh`      | Every turn (live)       | `context_window` JSON | Not included | Included (approx)   | Approximate   |
 
-**backfill** and **persist-session** parse the raw JSONL transcripts (main session + subagent files), applying per-model emission factors. Only `input_tokens` and `cache_creation_input_tokens` are counted. These feed the SQLite database used by reports.
+**backfill** and **persist-session** parse the raw JSONL transcripts (main session + subagent files), applying per-model emission factors. They deduplicate assistant messages by `(message.id, requestId)`, so resumed and compacted sessions are not double-counted (this matches `ccusage`; without it the token sum inflates roughly 3x). Each session stores its raw token breakdown (input, cache write, cache read, output), which feeds the SQLite database used by reports.
+
+**Cost** is the theoretical API list value (pay-as-you-go), not your subscription price: input, output, cache write (1.25x input), and cache read (0.1x input) at current Anthropic rates, set in `data/prices.json`. On deduplicated data it matches `ccusage`.
 
 **statusline** reads `context_window.total_input_tokens` from Claude Code at each turn. This value represents the current context size (not a cumulative total), includes cache reads, and does not account for subagent tokens. It's an indicative live display, not a data source for reports.
 
-_\*Claude Code does not expose `cache_read_input_tokens` separately in the statusline JSON. Parsing JSONL incrementally would be too slow for a per-turn display. A proper fix would require Anthropic to expose the token breakdown in the status hook API._
+### Surviving the 30-day transcript purge
+
+Claude Code deletes JSONL transcripts after about 30 days, so the SQLite database is the durable record. The `Stop` hook captures each session before its transcript ages out, and a once-a-day background re-scan (`SessionStart` hook, `safety-rescan.sh`) catches any session the `Stop` hook missed while its transcript still exists. Because each row stores raw token counts, `recompute.sh` regenerates cost and CO2 from `data/factors.json` + `data/prices.json` at any time, with no transcript needed. When Anthropic changes a price or a factor is revised, edit the config and run:
+
+```bash
+bash scripts/recompute.sh
+```
 
 ## Commands
 
@@ -135,13 +143,15 @@ _\*Claude Code does not expose `cache_read_input_tokens` separately in the statu
 <details>
 <summary>Scripts (run automatically, rarely needed manually)</summary>
 
-| Script               | What it does                                                |
-| -------------------- | ----------------------------------------------------------- |
-| `setup.sh`           | Init database, backfill historical sessions, show total     |
-| `statusline.sh`      | Status line script (called automatically by Claude Code)    |
-| `persist-session.sh` | Stop hook (saves session data on exit)                      |
-| `backfill.sh`        | Re-parse all historical JSONL transcripts (incl. subagents) |
-| `generate-report.sh` | Export PNG report cards (CLI, with `--since` / `--all`)     |
+| Script               | What it does                                                                              |
+| -------------------- | ----------------------------------------------------------------------------------------- |
+| `setup.sh`           | Init database, backfill historical sessions, show total                                   |
+| `statusline.sh`      | Status line script (called automatically by Claude Code)                                  |
+| `persist-session.sh` | Stop hook (saves session data on exit)                                                    |
+| `safety-rescan.sh`   | SessionStart hook (throttled background re-scan, catches missed sessions)                 |
+| `backfill.sh`        | Re-parse all historical JSONL transcripts (incl. subagents)                               |
+| `recompute.sh`       | Re-derive cost/CO2 from stored tokens after a price/factor change (no transcripts needed) |
+| `generate-report.sh` | Export PNG report cards (CLI, with `--since` / `--all`)                                   |
 
 </details>
 
@@ -158,7 +168,7 @@ Factors from [Jegham et al. 2025](https://arxiv.org/abs/2505.09598), a peer-revi
 **Important: these are order-of-magnitude estimates, not precise measurements.**
 
 - Sonnet factors are derived from Jegham et al. direct measurements. Opus and Haiku are extrapolated (no public data from Anthropic on per-model energy consumption).
-- Cache read tokens are excluded from the calculation (only `input_tokens` and `cache_creation_input_tokens` are counted). Cache reads represent the majority of tokens in Claude Code but consume negligible energy.
+- Cache read tokens are counted at a reduced factor (default 0.08 of an input token, set in `data/factors.json`). A cached token skips prefill compute but still incurs decode-phase memory reads, so it is cheap but not free. This is an engineering estimate derived from the literature, not Anthropic's 0.1x billing ratio. See [METHODOLOGY.md](METHODOLOGY.md).
 - Carbon intensity uses AWS grid-average (0.287 kgCO2e/kWh), not real-time grid data.
 - Anthropic does not publish Scope 1, 2, or 3 emissions. These estimates are independent and based on academic research, not provider data.
 

--- a/data/factors.json
+++ b/data/factors.json
@@ -2,6 +2,8 @@
   "_methodology": "Jegham et al. 2025 - AWS PUE 1.14, CIF 0.287 kgCO2e/kWh",
   "_units": "gCO2e per million tokens",
   "_source": "https://arxiv.org/abs/2505.09598",
+  "_cache_read_factor": "Energy of a cache_read token as a fraction of an uncached input token. Engineering estimate (~0.08, defensible range 0.05-0.15) derived from the decode-phase KV re-read residual. NOT Anthropic's 0.1x billing ratio (a price, not energy). See METHODOLOGY.md.",
+  "cache_read_factor": 0.08,
   "models": {
     "opus": { "input": 500, "output": 3000 },
     "sonnet": { "input": 190, "output": 1140 },

--- a/data/prices.json
+++ b/data/prices.json
@@ -1,0 +1,12 @@
+{
+  "_units": "USD per million tokens — current Anthropic list price (pay-as-you-go API value).",
+  "_note": "Opus 4.6+ is 5/25 (the retired 4.0/4.1 was 15/75). cache_write = input x cache_write_multiplier (5-min TTL), cache_read = input x cache_read_multiplier. After editing, run scripts/recompute.sh to re-derive cost_usd for all raw-token rows without needing the (purged) JSONL.",
+  "_updated": "2026-06-05",
+  "models": {
+    "opus": { "input": 5, "output": 25 },
+    "sonnet": { "input": 3, "output": 15 },
+    "haiku": { "input": 1, "output": 5 }
+  },
+  "cache_write_multiplier": 1.25,
+  "cache_read_multiplier": 0.1
+}

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -10,6 +10,17 @@
           }
         ]
       }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/safety-rescan.sh"
+          }
+        ]
+      }
     ]
   }
 }

--- a/scripts/backfill.sh
+++ b/scripts/backfill.sh
@@ -3,23 +3,41 @@ set -euo pipefail
 
 # backfill.sh — Parse all historical Claude Code JSONL transcripts and insert into carbon.db.
 # Includes subagent JSONL files in the calculation (each with its own model/factor).
+# Deduplicates assistant messages by (message.id, requestId) so resumed/compacted sessions
+# that replay prior messages within a file are not double-counted (matches ccusage).
+# Stores raw token counts (input, cache_write, cache_read, output) per session so cost and
+# CO2 can be re-derived later via recompute.sh without the (30-day-purged) JSONL.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FACTORS_FILE="${SCRIPT_DIR}/../data/factors.json"
-DB_PATH="${HOME}/.claude/claude-carbon/carbon.db"
+PRICES_FILE="${SCRIPT_DIR}/../data/prices.json"
+DB_PATH="${CLAUDE_CARBON_DB:-${HOME}/.claude/claude-carbon/carbon.db}"
 
-# Load emission factors once
+# Rows written by this version of the methodology (raw-token columns populated).
+METHODOLOGY_VERSION=2
+
+# Ensure schema exists and is migrated (idempotent; safe on fresh or pre-existing DBs).
+sqlite3 "$DB_PATH" "CREATE TABLE IF NOT EXISTS sessions (session_id TEXT PRIMARY KEY, project TEXT, model TEXT, input_tokens INTEGER, output_tokens INTEGER, cache_read_tokens INTEGER DEFAULT 0, cache_creation_tokens INTEGER DEFAULT 0, cost_usd REAL, co2_grams REAL, started_at TEXT, ended_at TEXT, source TEXT DEFAULT 'live', methodology_version INTEGER DEFAULT 1); CREATE INDEX IF NOT EXISTS idx_sessions_year ON sessions(started_at);" 2>/dev/null || true
+sqlite3 "$DB_PATH" "ALTER TABLE sessions ADD COLUMN cache_read_tokens INTEGER DEFAULT 0;" 2>/dev/null || true
+sqlite3 "$DB_PATH" "ALTER TABLE sessions ADD COLUMN cache_creation_tokens INTEGER DEFAULT 0;" 2>/dev/null || true
+sqlite3 "$DB_PATH" "ALTER TABLE sessions ADD COLUMN methodology_version INTEGER DEFAULT 1;" 2>/dev/null || true
+
+# Load emission factors once (gCO2e per million tokens)
 FACTOR_OPUS_IN="$(jq -r '.models.opus.input' "$FACTORS_FILE")"
 FACTOR_OPUS_OUT="$(jq -r '.models.opus.output' "$FACTORS_FILE")"
 FACTOR_SONNET_IN="$(jq -r '.models.sonnet.input' "$FACTORS_FILE")"
 FACTOR_SONNET_OUT="$(jq -r '.models.sonnet.output' "$FACTORS_FILE")"
 FACTOR_HAIKU_IN="$(jq -r '.models.haiku.input' "$FACTORS_FILE")"
 FACTOR_HAIKU_OUT="$(jq -r '.models.haiku.output' "$FACTORS_FILE")"
+# Energy of a cache_read token as a fraction of an uncached input token (see METHODOLOGY.md).
+CACHE_READ_FACTOR="$(jq -r '.cache_read_factor // 0.08' "$FACTORS_FILE")"
 
-# Pricing per million tokens
-PRICE_OPUS_IN="15"; PRICE_OPUS_OUT="75"
-PRICE_SONNET_IN="3"; PRICE_SONNET_OUT="15"
-PRICE_HAIKU_IN="0.80"; PRICE_HAIKU_OUT="4"
+# Load pricing once (USD per million tokens, current Anthropic list price)
+PRICE_OPUS_IN="$(jq -r '.models.opus.input' "$PRICES_FILE")";     PRICE_OPUS_OUT="$(jq -r '.models.opus.output' "$PRICES_FILE")"
+PRICE_SONNET_IN="$(jq -r '.models.sonnet.input' "$PRICES_FILE")"; PRICE_SONNET_OUT="$(jq -r '.models.sonnet.output' "$PRICES_FILE")"
+PRICE_HAIKU_IN="$(jq -r '.models.haiku.input' "$PRICES_FILE")";   PRICE_HAIKU_OUT="$(jq -r '.models.haiku.output' "$PRICES_FILE")"
+CACHE_WRITE_MULT="$(jq -r '.cache_write_multiplier // 1.25' "$PRICES_FILE")"
+CACHE_READ_MULT="$(jq -r '.cache_read_multiplier // 0.1' "$PRICES_FILE")"
 
 ADDED=0
 SKIPPED=0
@@ -28,42 +46,64 @@ ERRORS=0
 # UUID regex pattern
 UUID_PATTERN='^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
 
-# Helper: aggregate tokens from a JSONL file (excludes cache_read)
-# Tries fast jq -s first, falls back to line-by-line for corrupted files
+# Helper: aggregate tokens from a JSONL file.
+# Deduplicates assistant messages by (message.id|requestId), keeping the LAST occurrence
+# (streaming snapshots grow output_tokens; the last carries the final value). Tracks
+# input, cache_creation (write), cache_read, and output separately.
+# Tries fast jq -s first, falls back to line-by-line for corrupted files.
 aggregate_jsonl() {
   local file="$1"
   local result
   # Fast path: slurp entire file
   result="$(jq -s '
-    [.[] | select(.type == "assistant" and .message.usage != null)] |
-    {
-      input_tokens: (map(.message.usage.input_tokens // 0) | add // 0),
-      cache_creation: (map(.message.usage.cache_creation_input_tokens // 0) | add // 0),
-      output_tokens: (map(.message.usage.output_tokens // 0) | add // 0),
-      models: ([.[] | .message.model // ""] | map(select(length > 0))),
-      first_ts: (map(.timestamp // "") | map(select(length > 0)) | sort | first // ""),
-      last_ts: (map(.timestamp // "") | map(select(length > 0)) | sort | last // "")
-    } |
-    .total_input = (.input_tokens + .cache_creation)
+    [.[] | select(.type == "assistant" and .message.usage != null)] as $all
+    | (
+        ($all | map(select(.message.id != null and .requestId != null))
+              | reduce .[] as $m ({}; .[($m.message.id|tostring) + "|" + ($m.requestId|tostring)] = $m)
+              | [.[]])
+        + ($all | map(select(.message.id == null or .requestId == null)))
+      ) as $d
+    | {
+        input_tokens:   ($d | map(.message.usage.input_tokens // 0) | add // 0),
+        cache_creation: ($d | map(.message.usage.cache_creation_input_tokens // 0) | add // 0),
+        cache_read:     ($d | map(.message.usage.cache_read_input_tokens // 0) | add // 0),
+        output_tokens:  ($d | map(.message.usage.output_tokens // 0) | add // 0),
+        models:         ($d | map(.message.model // "") | map(select(length > 0))),
+        first_ts:       ($d | map(.timestamp // "") | map(select(length > 0)) | sort | first // ""),
+        last_ts:        ($d | map(.timestamp // "") | map(select(length > 0)) | sort | last // "")
+      }
   ' "$file" 2>/dev/null)" && echo "$result" && return 0
 
-  # Slow path: line-by-line (tolerates corrupted lines)
+  # Slow path: line-by-line (tolerates corrupted lines), same dedup applied at the end.
   while IFS= read -r line; do
-    echo "$line" | jq 'select(.type == "assistant" and .message.usage != null) | {
+    echo "$line" | jq -c 'select(.type == "assistant" and .message.usage != null) | {
       input_tokens: (.message.usage.input_tokens // 0),
       cache_creation: (.message.usage.cache_creation_input_tokens // 0),
+      cache_read: (.message.usage.cache_read_input_tokens // 0),
       output_tokens: (.message.usage.output_tokens // 0),
       model: (.message.model // ""),
+      id: (.message.id // null),
+      rid: (.requestId // null),
       ts: (.timestamp // "")
     }' 2>/dev/null
-  done < "$file" | jq -s '{
-    input_tokens: (map(.input_tokens) | add // 0),
-    cache_creation: (map(.cache_creation) | add // 0),
-    output_tokens: (map(.output_tokens) | add // 0),
-    models: [.[].model | select(length > 0)],
-    first_ts: ([.[].ts | select(length > 0)] | sort | first // ""),
-    last_ts: ([.[].ts | select(length > 0)] | sort | last // "")
-  } | .total_input = (.input_tokens + .cache_creation)' 2>/dev/null
+  done < "$file" | jq -s '
+    . as $all
+    | (
+        ($all | map(select(.id != null and .rid != null))
+              | reduce .[] as $m ({}; .[($m.id|tostring) + "|" + ($m.rid|tostring)] = $m)
+              | [.[]])
+        + ($all | map(select(.id == null or .rid == null)))
+      ) as $d
+    | {
+        input_tokens:   ($d | map(.input_tokens) | add // 0),
+        cache_creation: ($d | map(.cache_creation) | add // 0),
+        cache_read:     ($d | map(.cache_read) | add // 0),
+        output_tokens:  ($d | map(.output_tokens) | add // 0),
+        models:         ($d | map(.model) | map(select(length > 0))),
+        first_ts:       ($d | map(.ts) | map(select(length > 0)) | sort | first // ""),
+        last_ts:        ($d | map(.ts) | map(select(length > 0)) | sort | last // "")
+      }
+  ' 2>/dev/null
 }
 
 # Helper: resolve model family from model string
@@ -97,15 +137,19 @@ get_price_out() {
   esac
 }
 
-# Helper: compute CO2 and cost for a JSONL file with its own model
+# Helper: compute CO2 and theoretical API cost for a JSONL file with its own model.
+# CO2  = (input + cache_write) * factor_in + cache_read * (factor_in * CACHE_READ_FACTOR) + output * factor_out
+# Cost = input * pin + cache_write * (CACHE_WRITE_MULT*pin) + cache_read * (CACHE_READ_MULT*pin) + output * pout
+# Returns: total_input(=input+cache_write) cache_creation cache_read output co2 cost
 compute_co2_cost() {
   local aggregated="$1"
-  local total_in out family fin fout pin pout co2 cost
+  local it cw cr out family fin fout pin pout co2 cost total_input model_raw
 
-  total_in="$(echo "$aggregated" | jq -r '.total_input // 0')"
+  it="$(echo "$aggregated" | jq -r '.input_tokens // 0')"
+  cw="$(echo "$aggregated" | jq -r '.cache_creation // 0')"
+  cr="$(echo "$aggregated" | jq -r '.cache_read // 0')"
   out="$(echo "$aggregated" | jq -r '.output_tokens // 0')"
 
-  local model_raw
   model_raw="$(echo "$aggregated" | jq -r '
     .models |
     if length == 0 then "claude-sonnet"
@@ -119,10 +163,13 @@ compute_co2_cost() {
   pin="$(get_price_in "$family")"
   pout="$(get_price_out "$family")"
 
-  co2="$(echo "$total_in $fin $out $fout" | LC_ALL=C awk '{printf "%.4f", ($1 * $2 + $3 * $4) / 1000000}')"
-  cost="$(echo "$total_in $pin $out $pout" | LC_ALL=C awk '{printf "%.6f", ($1 * $2 + $3 * $4) / 1000000}')"
+  co2="$(echo "$it $cw $cr $out $fin $fout $CACHE_READ_FACTOR" | LC_ALL=C awk \
+    '{printf "%.4f", (($1 + $2) * $5 + $3 * ($5 * $7) + $4 * $6) / 1000000}')"
+  cost="$(echo "$it $cw $cr $out $pin $pout $CACHE_WRITE_MULT $CACHE_READ_MULT" | LC_ALL=C awk \
+    '{printf "%.6f", ($1 * $5 + $2 * ($5 * $7) + $3 * ($5 * $8) + $4 * $6) / 1000000}')"
 
-  echo "$total_in $out $co2 $cost"
+  total_input="$(echo "$it $cw" | LC_ALL=C awk '{printf "%d", $1 + $2}')"
+  echo "$total_input $cw $cr $out $co2 $cost"
 }
 
 # Scan all JSONL files under ~/.claude/projects/, max 2 levels deep
@@ -164,7 +211,7 @@ while IFS= read -r JSONL_FILE; do
   LAST_TS="$(echo "$AGGREGATED" | jq -r '.last_ts // ""')"
 
   # Compute CO2/cost for main session
-  read -r TOTAL_INPUT OUTPUT_TOKENS CO2_G COST_USD <<< "$(compute_co2_cost "$AGGREGATED")"
+  read -r TOTAL_INPUT CACHE_CREATION CACHE_READ OUTPUT_TOKENS CO2_G COST_USD <<< "$(compute_co2_cost "$AGGREGATED")"
 
   # Aggregate subagent JSONL files (each has its own model)
   SUBAGENT_DIR="$(dirname "$JSONL_FILE")/${SESSION_ID}/subagents"
@@ -173,10 +220,12 @@ while IFS= read -r JSONL_FILE; do
       [ -f "$SUB_FILE" ] || continue
       SUB_AGG="$(aggregate_jsonl "$SUB_FILE")" || continue
 
-      read -r SUB_IN SUB_OUT SUB_CO2 SUB_COST <<< "$(compute_co2_cost "$SUB_AGG")"
+      read -r SUB_IN SUB_CW SUB_CR SUB_OUT SUB_CO2 SUB_COST <<< "$(compute_co2_cost "$SUB_AGG")"
 
       # Add to session totals
       TOTAL_INPUT="$(echo "$TOTAL_INPUT $SUB_IN" | LC_ALL=C awk '{printf "%d", $1 + $2}')"
+      CACHE_CREATION="$(echo "$CACHE_CREATION $SUB_CW" | LC_ALL=C awk '{printf "%d", $1 + $2}')"
+      CACHE_READ="$(echo "$CACHE_READ $SUB_CR" | LC_ALL=C awk '{printf "%d", $1 + $2}')"
       OUTPUT_TOKENS="$(echo "$OUTPUT_TOKENS $SUB_OUT" | LC_ALL=C awk '{printf "%d", $1 + $2}')"
       CO2_G="$(echo "$CO2_G $SUB_CO2" | LC_ALL=C awk '{printf "%.4f", $1 + $2}')"
       COST_USD="$(echo "$COST_USD $SUB_COST" | LC_ALL=C awk '{printf "%.6f", $1 + $2}')"
@@ -210,7 +259,7 @@ while IFS= read -r JSONL_FILE; do
   LAST_TS="${LAST_TS//\'/\'\'}"
 
   # Insert into DB
-  sqlite3 "$DB_PATH" "INSERT OR IGNORE INTO sessions (session_id, project, model, input_tokens, output_tokens, cost_usd, co2_grams, started_at, ended_at, source) VALUES ('${SESSION_ID}', '${PROJECT}', '${MODEL_RAW}', ${TOTAL_INPUT}, ${OUTPUT_TOKENS}, ${COST_USD}, ${CO2_G}, '${FIRST_TS}', '${LAST_TS}', 'backfill');" 2>/dev/null || { ERRORS=$((ERRORS + 1)); continue; }
+  sqlite3 "$DB_PATH" "INSERT OR IGNORE INTO sessions (session_id, project, model, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens, cost_usd, co2_grams, started_at, ended_at, source, methodology_version) VALUES ('${SESSION_ID}', '${PROJECT}', '${MODEL_RAW}', ${TOTAL_INPUT}, ${OUTPUT_TOKENS}, ${CACHE_READ}, ${CACHE_CREATION}, ${COST_USD}, ${CO2_G}, '${FIRST_TS}', '${LAST_TS}', 'backfill', ${METHODOLOGY_VERSION});" 2>/dev/null || { ERRORS=$((ERRORS + 1)); continue; }
 
   ADDED=$((ADDED + 1))
 

--- a/scripts/generate-report.sh
+++ b/scripts/generate-report.sh
@@ -17,6 +17,11 @@ SINCE="${YEAR}-01-01"
 SINCE_LABEL_FR="janvier ${YEAR}"
 SINCE_LABEL_EN="January ${YEAR}"
 LANG_FILTER="" # empty = both
+LABEL_AUTO=1   # default mode: derive the "since" label from the earliest real session
+
+# Full month names for the auto-derived label (index 1-12)
+MONTHS_FR=("" "janvier" "février" "mars" "avril" "mai" "juin" "juillet" "août" "septembre" "octobre" "novembre" "décembre")
+MONTHS_EN=("" "January" "February" "March" "April" "May" "June" "July" "August" "September" "October" "November" "December")
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -24,12 +29,14 @@ while [[ $# -gt 0 ]]; do
       SINCE="$2"
       SINCE_LABEL_FR="$2"
       SINCE_LABEL_EN="$2"
+      LABEL_AUTO=0
       shift 2
       ;;
     --all)
       SINCE=""
       SINCE_LABEL_FR="le début"
       SINCE_LABEL_EN="the beginning"
+      LABEL_AUTO=0
       shift
       ;;
     --lang)
@@ -95,6 +102,17 @@ read -r TOTAL_CO2_VALUE TOTAL_CO2_UNIT <<< "$(format_co2 "$TOTAL_CO2_RAW")"
 TOTAL_COST="$(echo "$TOTAL_COST_RAW" | LC_ALL=C awk '{printf "%.0f", $1}')"
 FIRST_DATE="$(echo "$FIRST_DATE_RAW" | cut -c1-10)"
 EQUIV_KM="$(echo "$TOTAL_CO2_RAW" | LC_ALL=C awk '{printf "%.1f", $1/120}')"
+
+# In default mode, label the report with the actual earliest session month, not Jan 1st
+# (transcripts older than ~30 days are purged, so the real data rarely starts in January).
+if [ "$LABEL_AUTO" = "1" ] && [ -n "$FIRST_DATE" ]; then
+  _lm="$(echo "$FIRST_DATE" | cut -c6-7 | sed 's/^0//')"
+  _ly="$(echo "$FIRST_DATE" | cut -c1-4)"
+  if [ -n "$_lm" ] && [ "$_lm" -ge 1 ] 2>/dev/null && [ "$_lm" -le 12 ] 2>/dev/null; then
+    SINCE_LABEL_FR="${MONTHS_FR[$_lm]} ${_ly}"
+    SINCE_LABEL_EN="${MONTHS_EN[$_lm]} ${_ly}"
+  fi
+fi
 
 # Format tokens (M)
 TOTAL_TOKENS="$(echo "$TOTAL_TOKENS_RAW" | LC_ALL=C awk '{printf "%.0f", $1/1000000}')"
@@ -302,11 +320,16 @@ PW_PATH="$(node -e "try { console.log(require.resolve('playwright-core').replace
 
 if [ -z "$PW_PATH" ]; then
   _npm_global_root="$(npm root -g 2>/dev/null || true)"
+  # Check both flattened (playwright-core installed directly) and nested (installed as a
+  # dependency of the full "playwright" package) locations.
   for candidate in \
     "${_npm_global_root}/playwright-core" \
+    "${_npm_global_root}/playwright/node_modules/playwright-core" \
     "${HOME}/node_modules/playwright-core" \
+    "${HOME}/node_modules/playwright/node_modules/playwright-core" \
     "${HOME}/claude cowork/node_modules/playwright-core" \
-    "/opt/homebrew/lib/node_modules/playwright-core"; do
+    "/opt/homebrew/lib/node_modules/playwright-core" \
+    "/opt/homebrew/lib/node_modules/playwright/node_modules/playwright-core"; do
     if [ -d "$candidate" ]; then
       PW_PATH="$candidate"
       break

--- a/scripts/persist-session.sh
+++ b/scripts/persist-session.sh
@@ -1,15 +1,26 @@
 #!/usr/bin/env bash
 # persist-session.sh — Stop hook: persist session CO2 data to SQLite DB.
-# Parses the session JSONL + subagent JSONLs directly (same logic as backfill)
-# to ensure cache_read tokens are excluded and subagents are counted.
+# Parses the session JSONL + subagent JSONLs directly (same logic as backfill):
+# deduplicates assistant messages by (message.id, requestId) so replayed messages
+# in resumed/compacted sessions are not double-counted, and stores the raw token
+# breakdown (input, cache_write, cache_read, output) so cost/CO2 can be re-derived later
+# via recompute.sh without the (30-day-purged) JSONL.
 # Intentionally no set -euo pipefail: this hook must exit 0 silently in all cases.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FACTORS_FILE="${SCRIPT_DIR}/../data/factors.json"
-DB_PATH="${HOME}/.claude/claude-carbon/carbon.db"
+PRICES_FILE="${SCRIPT_DIR}/../data/prices.json"
+DB_PATH="${CLAUDE_CARBON_DB:-${HOME}/.claude/claude-carbon/carbon.db}"
+
+METHODOLOGY_VERSION=2
 
 # Exit silently if DB doesn't exist (plugin not set up yet)
 [ -f "$DB_PATH" ] || exit 0
+
+# Migrate schema if needed (idempotent; no-ops once the columns exist)
+sqlite3 "$DB_PATH" "ALTER TABLE sessions ADD COLUMN cache_read_tokens INTEGER DEFAULT 0;" 2>/dev/null || true
+sqlite3 "$DB_PATH" "ALTER TABLE sessions ADD COLUMN cache_creation_tokens INTEGER DEFAULT 0;" 2>/dev/null || true
+sqlite3 "$DB_PATH" "ALTER TABLE sessions ADD COLUMN methodology_version INTEGER DEFAULT 1;" 2>/dev/null || true
 
 # Load emission factors once
 FACTOR_OPUS_IN="$(jq -r '.models.opus.input' "$FACTORS_FILE" 2>/dev/null)" || exit 0
@@ -18,13 +29,19 @@ FACTOR_SONNET_IN="$(jq -r '.models.sonnet.input' "$FACTORS_FILE" 2>/dev/null)" |
 FACTOR_SONNET_OUT="$(jq -r '.models.sonnet.output' "$FACTORS_FILE" 2>/dev/null)" || exit 0
 FACTOR_HAIKU_IN="$(jq -r '.models.haiku.input' "$FACTORS_FILE" 2>/dev/null)" || exit 0
 FACTOR_HAIKU_OUT="$(jq -r '.models.haiku.output' "$FACTORS_FILE" 2>/dev/null)" || exit 0
+# Energy of a cache_read token as a fraction of an uncached input token (see METHODOLOGY.md).
+CACHE_READ_FACTOR="$(jq -r '.cache_read_factor // 0.08' "$FACTORS_FILE" 2>/dev/null)" || CACHE_READ_FACTOR="0.08"
 
-# Theoretical API pricing per million tokens (public list price, same as backfill.sh).
-# The Stop hook doesn't provide the actual billed cost, so we estimate the API
-# price the usage would have cost outside of a subscription.
-PRICE_OPUS_IN="15"; PRICE_OPUS_OUT="75"
-PRICE_SONNET_IN="3"; PRICE_SONNET_OUT="15"
-PRICE_HAIKU_IN="0.80"; PRICE_HAIKU_OUT="4"
+# Load pricing once (USD per million tokens, current Anthropic list price).
+# The Stop hook doesn't provide the actual billed cost, so we estimate the API list value.
+PRICE_OPUS_IN="$(jq -r '.models.opus.input' "$PRICES_FILE" 2>/dev/null)" || PRICE_OPUS_IN="5"
+PRICE_OPUS_OUT="$(jq -r '.models.opus.output' "$PRICES_FILE" 2>/dev/null)" || PRICE_OPUS_OUT="25"
+PRICE_SONNET_IN="$(jq -r '.models.sonnet.input' "$PRICES_FILE" 2>/dev/null)" || PRICE_SONNET_IN="3"
+PRICE_SONNET_OUT="$(jq -r '.models.sonnet.output' "$PRICES_FILE" 2>/dev/null)" || PRICE_SONNET_OUT="15"
+PRICE_HAIKU_IN="$(jq -r '.models.haiku.input' "$PRICES_FILE" 2>/dev/null)" || PRICE_HAIKU_IN="1"
+PRICE_HAIKU_OUT="$(jq -r '.models.haiku.output' "$PRICES_FILE" 2>/dev/null)" || PRICE_HAIKU_OUT="5"
+CACHE_WRITE_MULT="$(jq -r '.cache_write_multiplier // 1.25' "$PRICES_FILE" 2>/dev/null)" || CACHE_WRITE_MULT="1.25"
+CACHE_READ_MULT="$(jq -r '.cache_read_multiplier // 0.1' "$PRICES_FILE" 2>/dev/null)" || CACHE_READ_MULT="0.1"
 
 # Read stdin
 INPUT="$(cat 2>/dev/null)" || exit 0
@@ -39,41 +56,67 @@ SESSION_ID="$(echo "$INPUT" | jq -r '.session_id // ""' 2>/dev/null)" || exit 0
 TRANSCRIPT_PATH="$(echo "$INPUT" | jq -r '.transcript_path // ""' 2>/dev/null)" || exit 0
 CURRENT_DIR="$(echo "$INPUT" | jq -r '.cwd // ""' 2>/dev/null)" || exit 0
 
-# Helper: aggregate tokens from a JSONL file (excludes cache_read)
+# Helper: aggregate tokens from a JSONL file.
+# Dedups assistant messages by (message.id|requestId) keeping the LAST occurrence; tracks
+# input, cache_creation (write), cache_read, and output separately.
 aggregate_jsonl() {
   local result
   result="$(jq -s '
-    [.[] | select(.type == "assistant" and .message.usage != null)] |
-    {
-      input_tokens: (map(.message.usage.input_tokens // 0) | add // 0),
-      cache_creation: (map(.message.usage.cache_creation_input_tokens // 0) | add // 0),
-      output_tokens: (map(.message.usage.output_tokens // 0) | add // 0),
-      models: ([.[] | .message.model // ""] | map(select(length > 0)))
-    } |
-    .total_input = (.input_tokens + .cache_creation)
+    [.[] | select(.type == "assistant" and .message.usage != null)] as $all
+    | (
+        ($all | map(select(.message.id != null and .requestId != null))
+              | reduce .[] as $m ({}; .[($m.message.id|tostring) + "|" + ($m.requestId|tostring)] = $m)
+              | [.[]])
+        + ($all | map(select(.message.id == null or .requestId == null)))
+      ) as $d
+    | {
+        input_tokens:   ($d | map(.message.usage.input_tokens // 0) | add // 0),
+        cache_creation: ($d | map(.message.usage.cache_creation_input_tokens // 0) | add // 0),
+        cache_read:     ($d | map(.message.usage.cache_read_input_tokens // 0) | add // 0),
+        output_tokens:  ($d | map(.message.usage.output_tokens // 0) | add // 0),
+        models:         ($d | map(.message.model // "") | map(select(length > 0)))
+      }
   ' "$1" 2>/dev/null)" && echo "$result" && return 0
-  # Fallback: line-by-line for corrupted files
+  # Fallback: line-by-line for corrupted files, same dedup applied at the end.
   while IFS= read -r line; do
-    echo "$line" | jq 'select(.type == "assistant" and .message.usage != null) | {
+    echo "$line" | jq -c 'select(.type == "assistant" and .message.usage != null) | {
       input_tokens: (.message.usage.input_tokens // 0),
       cache_creation: (.message.usage.cache_creation_input_tokens // 0),
+      cache_read: (.message.usage.cache_read_input_tokens // 0),
       output_tokens: (.message.usage.output_tokens // 0),
-      model: (.message.model // "")
+      model: (.message.model // ""),
+      id: (.message.id // null),
+      rid: (.requestId // null)
     }' 2>/dev/null
-  done < "$1" | jq -s '{
-    input_tokens: (map(.input_tokens) | add // 0),
-    cache_creation: (map(.cache_creation) | add // 0),
-    output_tokens: (map(.output_tokens) | add // 0),
-    models: [.[].model | select(length > 0)]
-  } | .total_input = (.input_tokens + .cache_creation)' 2>/dev/null
+  done < "$1" | jq -s '
+    . as $all
+    | (
+        ($all | map(select(.id != null and .rid != null))
+              | reduce .[] as $m ({}; .[($m.id|tostring) + "|" + ($m.rid|tostring)] = $m)
+              | [.[]])
+        + ($all | map(select(.id == null or .rid == null)))
+      ) as $d
+    | {
+        input_tokens:   ($d | map(.input_tokens) | add // 0),
+        cache_creation: ($d | map(.cache_creation) | add // 0),
+        cache_read:     ($d | map(.cache_read) | add // 0),
+        output_tokens:  ($d | map(.output_tokens) | add // 0),
+        models:         ($d | map(.model) | map(select(length > 0)))
+      }
+  ' 2>/dev/null
 }
 
-# Helper: compute CO2 and theoretical API cost for aggregated data using its own model
+# Helper: compute CO2 and theoretical API cost for aggregated data using its own model.
+# CO2  = (input + cache_write) * factor_in + cache_read * (factor_in * CACHE_READ_FACTOR) + output * factor_out
+# Cost = input * pin + cache_write * (CACHE_WRITE_MULT*pin) + cache_read * (CACHE_READ_MULT*pin) + output * pout
+# Returns: total_input(=input+cache_write) cache_creation cache_read output co2 cost
 compute_co2() {
   local agg="$1"
-  local tin out model family fin fout pin pout
+  local it cw cr out model family fin fout pin pout co2 cost total_input
 
-  tin="$(echo "$agg" | jq -r '.total_input // 0')"
+  it="$(echo "$agg" | jq -r '.input_tokens // 0')"
+  cw="$(echo "$agg" | jq -r '.cache_creation // 0')"
+  cr="$(echo "$agg" | jq -r '.cache_read // 0')"
   out="$(echo "$agg" | jq -r '.output_tokens // 0')"
   model="$(echo "$agg" | jq -r '.models | if length == 0 then "claude-sonnet" else group_by(.) | sort_by(-length) | first | first end')"
 
@@ -87,10 +130,12 @@ compute_co2() {
     *)     fin="$FACTOR_SONNET_IN"; fout="$FACTOR_SONNET_OUT"; pin="$PRICE_SONNET_IN"; pout="$PRICE_SONNET_OUT" ;;
   esac
 
-  local co2 cost
-  co2="$(echo "$tin $fin $out $fout" | LC_ALL=C awk '{printf "%.4f", ($1 * $2 + $3 * $4) / 1000000}')"
-  cost="$(echo "$tin $pin $out $pout" | LC_ALL=C awk '{printf "%.6f", ($1 * $2 + $3 * $4) / 1000000}')"
-  echo "$tin $out $co2 $cost"
+  co2="$(echo "$it $cw $cr $out $fin $fout $CACHE_READ_FACTOR" | LC_ALL=C awk \
+    '{printf "%.4f", (($1 + $2) * $5 + $3 * ($5 * $7) + $4 * $6) / 1000000}')"
+  cost="$(echo "$it $cw $cr $out $pin $pout $CACHE_WRITE_MULT $CACHE_READ_MULT" | LC_ALL=C awk \
+    '{printf "%.6f", ($1 * $5 + $2 * ($5 * $7) + $3 * ($5 * $8) + $4 * $6) / 1000000}')"
+  total_input="$(echo "$it $cw" | LC_ALL=C awk '{printf "%d", $1 + $2}')"
+  echo "$total_input $cw $cr $out $co2 $cost"
 }
 
 # Find the JSONL file: use transcript_path from hook, fallback to search by session_id
@@ -113,7 +158,7 @@ fi
 
 # Parse main JSONL
 MAIN_AGG="$(aggregate_jsonl "$JSONL_FILE")" || exit 0
-read -r INPUT_TOKENS OUTPUT_TOKENS CO2_G COST_USD <<< "$(compute_co2 "$MAIN_AGG")"
+read -r INPUT_TOKENS CACHE_CREATION CACHE_READ OUTPUT_TOKENS CO2_G COST_USD <<< "$(compute_co2 "$MAIN_AGG")"
 
 # Extract model from JSONL (not available in Stop hook JSON)
 MODEL_RAW="$(echo "$MAIN_AGG" | jq -r '.models | if length == 0 then "claude-sonnet" else group_by(.) | sort_by(-length) | first | first end' 2>/dev/null)" || MODEL_RAW="claude-sonnet"
@@ -125,8 +170,10 @@ if [ -d "$SUBAGENT_DIR" ]; then
     [ -f "$SUB_FILE" ] || continue
     SUB_AGG="$(aggregate_jsonl "$SUB_FILE")" || continue
 
-    read -r SUB_IN SUB_OUT SUB_CO2 SUB_COST <<< "$(compute_co2 "$SUB_AGG")"
+    read -r SUB_IN SUB_CW SUB_CR SUB_OUT SUB_CO2 SUB_COST <<< "$(compute_co2 "$SUB_AGG")"
     INPUT_TOKENS="$(echo "$INPUT_TOKENS $SUB_IN" | LC_ALL=C awk '{printf "%d", $1 + $2}')"
+    CACHE_CREATION="$(echo "$CACHE_CREATION $SUB_CW" | LC_ALL=C awk '{printf "%d", $1 + $2}')"
+    CACHE_READ="$(echo "$CACHE_READ $SUB_CR" | LC_ALL=C awk '{printf "%d", $1 + $2}')"
     OUTPUT_TOKENS="$(echo "$OUTPUT_TOKENS $SUB_OUT" | LC_ALL=C awk '{printf "%d", $1 + $2}')"
     CO2_G="$(echo "$CO2_G $SUB_CO2" | LC_ALL=C awk '{printf "%.4f", $1 + $2}')"
     COST_USD="$(echo "$COST_USD $SUB_COST" | LC_ALL=C awk '{printf "%.6f", $1 + $2}')"
@@ -146,6 +193,6 @@ MODEL_RAW="${MODEL_RAW//\'/\'\'}"
 NOW="${NOW//\'/\'\'}"
 
 # INSERT OR REPLACE into sessions (source='live', cost = theoretical API list price)
-sqlite3 "$DB_PATH" "INSERT OR REPLACE INTO sessions (session_id, project, model, input_tokens, output_tokens, cost_usd, co2_grams, started_at, ended_at, source) VALUES ('${SESSION_ID}', '${PROJECT}', '${MODEL_RAW}', ${INPUT_TOKENS}, ${OUTPUT_TOKENS}, ${COST_USD}, ${CO2_G}, COALESCE((SELECT started_at FROM sessions WHERE session_id='${SESSION_ID}'), '${NOW}'), '${NOW}', 'live');" 2>/dev/null || true
+sqlite3 "$DB_PATH" "INSERT OR REPLACE INTO sessions (session_id, project, model, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens, cost_usd, co2_grams, started_at, ended_at, source, methodology_version) VALUES ('${SESSION_ID}', '${PROJECT}', '${MODEL_RAW}', ${INPUT_TOKENS}, ${OUTPUT_TOKENS}, ${CACHE_READ}, ${CACHE_CREATION}, ${COST_USD}, ${CO2_G}, COALESCE((SELECT started_at FROM sessions WHERE session_id='${SESSION_ID}'), '${NOW}'), '${NOW}', 'live', ${METHODOLOGY_VERSION});" 2>/dev/null || true
 
 exit 0

--- a/scripts/recompute.sh
+++ b/scripts/recompute.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# recompute.sh — Re-derive cost_usd and co2_grams for stored sessions from their raw token
+# counts and the CURRENT data/factors.json + data/prices.json, without reading any JSONL.
+# Run this after changing pricing, CO2 factors, or the cache_read_factor.
+#
+# This is the answer to Anthropic's 30-day transcript purge: the raw token breakdown is
+# captured once (by the Stop hook, within the 30-day window) and frozen; everything derived
+# from it (cost, CO2) stays regenerable forever. Only rows with methodology_version >= 2
+# carry the full breakdown (regular input, cache_write, cache_read, output); earlier "legacy"
+# rows lack cache_read and are left untouched.
+#
+# Mixed-model sessions (subagents on a different model) are recomputed at the row's dominant
+# model, a small approximation; the original insert was model-accurate per subagent.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FACTORS_FILE="${CLAUDE_CARBON_FACTORS:-${SCRIPT_DIR}/../data/factors.json}"
+PRICES_FILE="${CLAUDE_CARBON_PRICES:-${SCRIPT_DIR}/../data/prices.json}"
+DB_PATH="${CLAUDE_CARBON_DB:-${HOME}/.claude/claude-carbon/carbon.db}"
+
+[ -f "$DB_PATH" ] || { echo "No database at ${DB_PATH}" >&2; exit 1; }
+
+# Emission factors (gCO2e per million tokens) + cache_read energy fraction
+F_OPUS_IN="$(jq -r '.models.opus.input' "$FACTORS_FILE")";    F_OPUS_OUT="$(jq -r '.models.opus.output' "$FACTORS_FILE")"
+F_SON_IN="$(jq -r '.models.sonnet.input' "$FACTORS_FILE")";   F_SON_OUT="$(jq -r '.models.sonnet.output' "$FACTORS_FILE")"
+F_HAI_IN="$(jq -r '.models.haiku.input' "$FACTORS_FILE")";    F_HAI_OUT="$(jq -r '.models.haiku.output' "$FACTORS_FILE")"
+CRF="$(jq -r '.cache_read_factor // 0.08' "$FACTORS_FILE")"
+
+# Prices (USD per million tokens) + cache multipliers
+P_OPUS_IN="$(jq -r '.models.opus.input' "$PRICES_FILE")";     P_OPUS_OUT="$(jq -r '.models.opus.output' "$PRICES_FILE")"
+P_SON_IN="$(jq -r '.models.sonnet.input' "$PRICES_FILE")";    P_SON_OUT="$(jq -r '.models.sonnet.output' "$PRICES_FILE")"
+P_HAI_IN="$(jq -r '.models.haiku.input' "$PRICES_FILE")";     P_HAI_OUT="$(jq -r '.models.haiku.output' "$PRICES_FILE")"
+CW_MULT="$(jq -r '.cache_write_multiplier // 1.25' "$PRICES_FILE")"
+CR_MULT="$(jq -r '.cache_read_multiplier // 0.1' "$PRICES_FILE")"
+
+# co2  = (input_tokens * fin + cache_read_tokens * (fin*CRF) + output_tokens * fout) / 1e6
+#        (input_tokens already = regular_input + cache_write, both at the input factor)
+# cost = ((input_tokens - cache_creation_tokens) * pin              -- regular input
+#         + cache_creation_tokens * (pin*CW_MULT)                   -- cache write
+#         + cache_read_tokens * (pin*CR_MULT)                       -- cache read
+#         + output_tokens * pout) / 1e6
+update_family() {
+  local where="$1" fin="$2" fout="$3" pin="$4" pout="$5"
+  sqlite3 "$DB_PATH" "
+    UPDATE sessions SET
+      co2_grams = (input_tokens*${fin} + cache_read_tokens*(${fin}*${CRF}) + output_tokens*${fout}) / 1000000.0,
+      cost_usd  = ((input_tokens - cache_creation_tokens)*${pin} + cache_creation_tokens*(${pin}*${CW_MULT}) + cache_read_tokens*(${pin}*${CR_MULT}) + output_tokens*${pout}) / 1000000.0
+    WHERE methodology_version >= 2 AND ${where};
+  "
+}
+
+update_family "model LIKE '%opus%'"  "$F_OPUS_IN" "$F_OPUS_OUT" "$P_OPUS_IN" "$P_OPUS_OUT"
+update_family "model LIKE '%haiku%'" "$F_HAI_IN"  "$F_HAI_OUT"  "$P_HAI_IN"  "$P_HAI_OUT"
+update_family "model NOT LIKE '%opus%' AND model NOT LIKE '%haiku%'" "$F_SON_IN" "$F_SON_OUT" "$P_SON_IN" "$P_SON_OUT"
+
+RECOMPUTED="$(sqlite3 "$DB_PATH" "SELECT COUNT(*) FROM sessions WHERE methodology_version >= 2;")"
+LEGACY="$(sqlite3 "$DB_PATH" "SELECT COUNT(*) FROM sessions WHERE methodology_version IS NULL OR methodology_version < 2;")"
+TOTAL_COST="$(sqlite3 "$DB_PATH" "SELECT printf('%.0f', COALESCE(SUM(cost_usd),0)) FROM sessions;")"
+TOTAL_CO2_KG="$(sqlite3 "$DB_PATH" "SELECT printf('%.0f', COALESCE(SUM(co2_grams),0)/1000.0) FROM sessions;")"
+
+echo "Recomputed ${RECOMPUTED} rows from raw tokens (left ${LEGACY} legacy rows untouched)."
+echo "DB totals now: \$${TOTAL_COST} / ${TOTAL_CO2_KG} kg CO2."

--- a/scripts/safety-rescan.sh
+++ b/scripts/safety-rescan.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# safety-rescan.sh — SessionStart hook: a throttled, backgrounded backfill that catches
+# sessions the Stop hook missed (crash, kill, hook temporarily disabled), as long as their
+# JSONL is still on disk (within Anthropic's ~30-day retention). backfill.sh uses
+# INSERT OR IGNORE, so already-captured sessions are skipped cheaply.
+# Must exit 0 immediately and never block session start.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DB_DIR="${HOME}/.claude/claude-carbon"
+DB_PATH="${CLAUDE_CARBON_DB:-${DB_DIR}/carbon.db}"
+STAMP="${DB_DIR}/.last-rescan"
+
+# Drain stdin so the hook never blocks on an unread pipe
+cat >/dev/null 2>&1 || true
+
+# Only if the plugin is set up
+[ -f "$DB_PATH" ] || exit 0
+
+# Throttle: skip if a rescan ran in the last 24h
+if [ -f "$STAMP" ]; then
+  MTIME="$(stat -f %m "$STAMP" 2>/dev/null || stat -c %Y "$STAMP" 2>/dev/null || echo 0)"
+  AGE=$(( $(date +%s) - MTIME ))
+  [ "$AGE" -lt 86400 ] && exit 0
+fi
+
+# Mark now, then run backfill fully detached so session start is never delayed
+touch "$STAMP" 2>/dev/null || true
+( setsid bash "${SCRIPT_DIR}/backfill.sh" >/dev/null 2>&1 < /dev/null & ) >/dev/null 2>&1 || \
+  ( bash "${SCRIPT_DIR}/backfill.sh" >/dev/null 2>&1 < /dev/null & ) >/dev/null 2>&1
+
+exit 0

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -41,14 +41,22 @@ CREATE TABLE IF NOT EXISTS sessions (
   model TEXT,
   input_tokens INTEGER,
   output_tokens INTEGER,
+  cache_read_tokens INTEGER DEFAULT 0,
+  cache_creation_tokens INTEGER DEFAULT 0,
   cost_usd REAL,
   co2_grams REAL,
   started_at TEXT,
   ended_at TEXT,
-  source TEXT DEFAULT 'live'
+  source TEXT DEFAULT 'live',
+  methodology_version INTEGER DEFAULT 1
 );
 CREATE INDEX IF NOT EXISTS idx_sessions_year ON sessions(started_at);
 SQL
+
+# Migrate pre-existing DBs that lack the newer columns (idempotent; errors ignored when present).
+sqlite3 "$DB_PATH" "ALTER TABLE sessions ADD COLUMN cache_read_tokens INTEGER DEFAULT 0;" 2>/dev/null || true
+sqlite3 "$DB_PATH" "ALTER TABLE sessions ADD COLUMN cache_creation_tokens INTEGER DEFAULT 0;" 2>/dev/null || true
+sqlite3 "$DB_PATH" "ALTER TABLE sessions ADD COLUMN methodology_version INTEGER DEFAULT 1;" 2>/dev/null || true
 
 echo "  Schema created."
 
@@ -107,6 +115,17 @@ if [ "${CLAUDE_CARBON_INSTALLER:-}" != "1" ]; then
           {
             "type": "command",
             "command": "${PLUGIN_DIR}/scripts/persist-session.sh"
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${PLUGIN_DIR}/scripts/safety-rescan.sh"
           }
         ]
       }


### PR DESCRIPTION
…oken storage

Token accounting was wrong on three axes and the stored numbers could not survive a methodology change. This corrects the numbers and makes them regenerable without the (30-day-purged) JSONL transcripts.

Correctness (backfill.sh, persist-session.sh):
- Deduplicate assistant messages by (message.id, requestId), keeping the last occurrence. Resumed/compacted sessions replay messages within a file (55% of assistant lines on observed data), which inflated token sums ~3x. Matches ccusage.
- Replace hardcoded $15/$75 (retired Opus 4.0/4.1) with current Anthropic list pricing from data/prices.json (Opus $5/$25, Sonnet $3/$15, Haiku $1/$5); charge cache_write at 1.25x input and cache_read at 0.1x input.
- Count cache_read in CO2 at cache_read_factor (0.08) of the input factor instead of excluding it. Engineering estimate of the decode-phase KV re-read residual, documented in METHODOLOGY.md; not the 0.1x billing ratio. On deduplicated data, cost now reconciles with ccusage (~$2,600 vs the old inflated $21,800).

Durability (surviving the 30-day transcript purge):
- Store the raw token breakdown (cache_creation_tokens, cache_read_tokens) and a methodology_version column, so cost/CO2 become pure functions of stored tokens.
- recompute.sh re-derives cost/CO2 for raw-token rows from factors.json/prices.json with no JSONL. Run after any price or factor change.
- safety-rescan.sh + SessionStart hook: throttled daily background backfill to catch sessions the Stop hook missed while their transcript still exists.

Misc:
- generate-report.sh: label the report from the actual earliest session month (not Jan 1), and find playwright-core whether installed standalone or nested under the playwright package.
- Idempotent ALTER TABLE migrations in setup/backfill/persist.
- CLAUDE_CARBON_DB / CLAUDE_CARBON_FACTORS / CLAUDE_CARBON_PRICES env overrides.
- gitignore .DS_Store and .playwright-mcp/.