### PR TITLE
fix: locale-safe carbon-report + correct backfill project names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2026-06-12
+
+### fix: LC_ALL=C in carbon-report skill awk calls (#10)
+
+The bash script in `skills/carbon-report/SKILL.md` called awk without `LC_ALL=C`. Under comma-decimal locales (de_DE, fr_FR), awk truncated values at the decimal point (431.7045 → 431) and rendered output with commas. `export LC_ALL=C` at the top of the script covers all seven calls, mirroring the fix already applied to `scripts/*.sh`.
+
+### fix: backfill.sh derives project name from cwd instead of directory name (#11)
+
+`backfill.sh` took the last hyphen-separated token of the transcript directory name, which destroyed real hyphens in project names (`billing-service` → `service`) and merged distinct projects. It now reads the first `cwd` from the transcript JSONL via `jq -n 'first(inputs ...)'` (no SIGPIPE under `set -o pipefail`) and takes its basename, matching `persist-session.sh`. Previously backfilled rows keep their old names; delete and re-run backfill to normalize (noted in README).
+
 ## 2026-04-21
 
 ### fix: restore reset time display when stdin passes epoch

--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ _\*Claude Code does not expose `cache_read_input_tokens` separately in the statu
 | `backfill.sh`        | Re-parse all historical JSONL transcripts (incl. subagents) |
 | `generate-report.sh` | Export PNG report cards (CLI, with `--since` / `--all`)     |
 
+Note: backfill now derives project names from the transcript's `cwd` (matching the live hook). Sessions backfilled before this change keep their old, possibly truncated names; delete those rows and re-run `backfill.sh` to normalize them.
+
 </details>
 
 ## Emission factors

--- a/scripts/backfill.sh
+++ b/scripts/backfill.sh
@@ -150,10 +150,13 @@ while IFS= read -r JSONL_FILE; do
     continue
   fi
 
-  # Extract project name from parent directory
-  PROJECT_DIR="$(basename "$(dirname "$JSONL_FILE")")"
-  PROJECT="$(echo "$PROJECT_DIR" | tr '-' '\n' | tail -1)"
-  if [ -z "$PROJECT" ]; then
+  # Project name = basename of the session's cwd, matching persist-session.sh.
+  # The transcript directory name encodes the full path with hyphens, so real
+  # hyphens in project names cannot be recovered from it.
+  PROJECT_CWD="$(jq -rn 'first(inputs | .cwd? // empty)' "$JSONL_FILE" 2>/dev/null || true)"
+  if [ -n "$PROJECT_CWD" ]; then
+    PROJECT="$(basename "$PROJECT_CWD")"
+  else
     PROJECT="unknown"
   fi
 

--- a/skills/carbon-report/SKILL.md
+++ b/skills/carbon-report/SKILL.md
@@ -8,6 +8,10 @@ Run the following bash script exactly as written and present the output to the u
 ```bash
 #!/usr/bin/env bash
 
+# Force C locale: comma-decimal locales (de_DE, fr_FR) make awk mis-parse
+# "431.7045" as 431 and print "431,0" instead of "431.7"
+export LC_ALL=C
+
 DB_PATH="${HOME}/.claude/claude-carbon/carbon.db"
 
 if [ ! -f "$DB_PATH" ]; then


### PR DESCRIPTION
## Summary
- Add `export LC_ALL=C` to the bash script in `skills/carbon-report/SKILL.md` so awk parses and prints decimals correctly under comma-decimal locales (de_DE, fr_FR)
- Derive the backfill project name from the transcript's `cwd` (basename) instead of the last hyphen-separated token of the directory name, matching `persist-session.sh`
- README note: previously backfilled rows keep their old names; delete and re-run backfill to normalize

Fixes #10
Fixes #11

## Test plan
- [x] `LC_ALL=de_DE.UTF-8` repro: `431.7045` → `431,0` before, `431.7` after
- [x] Real transcript: old method gave `carbon`, new gives `claude-carbon`
- [x] Edge cases (no `cwd`, malformed JSON line) fall back to `unknown` without killing the script under `set -euo pipefail`
- [x] `bash -n scripts/backfill.sh` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)