### PR TITLE
feat: exclude non-Anthropic models + Fable 5 model family

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## 2026-06-12
 
+### feat: exclude non-Anthropic models from cost/CO2 accounting (#7)
+
+Claude Code pointed at a local model (via `ANTHROPIC_BASE_URL`) was silently counted as Sonnet, with Sonnet datacenter factors and Anthropic API pricing. Sessions whose dominant model string does not contain `claude` (including `<synthetic>`) are now stored with raw tokens but `cost_usd = 0`, `co2_grams = 0` and a new `excluded` column set to 1, and filtered out of all reports (`/carbon-report`, `generate-report.sh`). The statusline shows 0g for those models. A user-configurable `exclude_models` pattern list in `data/factors.json` can exclude additional models by name. Schema migration is the usual idempotent `ALTER TABLE`; raw tokens are preserved so excluded rows can be re-priced by `recompute.sh` if local-model factors are ever added.
+
+### feat: Fable 5 model family (pricing + extrapolated emission factors)
+
+`claude-fable-5` / `claude-mythos-5` were falling into the Sonnet fallback of `resolve_family`, under-costing them by 70%. New `fable` family across all scripts (backfill, persist-session, recompute, statusline): pricing $10/$50 per Mtok (current Anthropic list price), emission factors 1000/6000 gCO2e/Mtok extrapolated from Opus by the 2x list-price ratio (no published measurement; same approach as the Opus 3x-Sonnet extrapolation, documented in METHODOLOGY.md).
+
 ### fix: LC_ALL=C in carbon-report skill awk calls (#10)
 
 The bash script in `skills/carbon-report/SKILL.md` called awk without `LC_ALL=C`. Under comma-decimal locales (de_DE, fr_FR), awk truncated values at the decimal point (431.7045 → 431) and rendered output with commas. `export LC_ALL=C` at the top of the script covers all seven calls, mirroring the fix already applied to `scripts/*.sh`.

--- a/METHODOLOGY.md
+++ b/METHODOLOGY.md
@@ -35,6 +35,7 @@ Factors are in gCO2e per million tokens. `cache_write_tokens` (`cache_creation_i
 
 | Model family | Input | Output | Source                     |
 | ------------ | ----- | ------ | -------------------------- |
+| Fable        | 1000  | 6000   | Extrapolated (2x Opus)     |
 | Opus         | 500   | 3000   | Extrapolated (3x Sonnet)   |
 | Sonnet       | 190   | 1140   | Measured (Jegham et al.)   |
 | Haiku        | 95    | 570    | Extrapolated (0.5x Sonnet) |
@@ -43,14 +44,19 @@ Factors are in gCO2e per million tokens. `cache_write_tokens` (`cache_creation_i
 
 Output tokens are ~6x more expensive than input tokens in terms of compute. During prefill (input processing), the model processes all input tokens in parallel. During decoding (output generation), each token requires a full forward pass through the model sequentially. This autoregressive step dominates energy consumption.
 
-## Why Opus and Haiku are extrapolated
+## Why Fable, Opus and Haiku are extrapolated
 
-The Jegham paper measured Sonnet-class models directly. Opus and Haiku factors are estimated by scaling:
+The Jegham paper measured Sonnet-class models directly. The other families are estimated by scaling:
 
+- Fable = 2x Opus (no published measurement for Fable 5 / Mythos 5; the list-price ratio, $10/$50 vs $5/$25, is used as a compute proxy)
 - Opus = 3x Sonnet (larger model, roughly proportional parameter count)
 - Haiku = 0.5x Sonnet (smaller model, lighter compute)
 
 These are order-of-magnitude estimates. Actual values depend on Anthropic's specific hardware configuration and batching strategies, which are not publicly available.
+
+## Excluded models (non-Anthropic)
+
+Claude Code can be pointed at non-Anthropic models (e.g. local models behind `ANTHROPIC_BASE_URL`). Their impact profile is not an AWS datacenter's, so neither the emission factors nor the API pricing apply. Sessions whose dominant model string does not contain `claude` (including the `<synthetic>` marker) are stored with their raw token counts but `cost_usd = 0`, `co2_grams = 0` and `excluded = 1`, and are left out of all report aggregates. Additional models can be excluded by name via the `exclude_models` patterns in `data/factors.json`. Because raw tokens are preserved, excluded sessions can be re-priced later by `recompute.sh` if factors for local models are ever added.
 
 ## Token counting and deduplication
 

--- a/README.md
+++ b/README.md
@@ -163,13 +163,15 @@ Factors from [Jegham et al. 2025](https://arxiv.org/abs/2505.09598), a peer-revi
 
 | Model  | Input (gCO2e/Mtok) | Output (gCO2e/Mtok) | Basis                      |
 | ------ | ------------------ | ------------------- | -------------------------- |
+| Fable  | 1000               | 6000                | Extrapolated (2x Opus)     |
 | Opus   | 500                | 3000                | Extrapolated (3x Sonnet)   |
 | Sonnet | 190                | 1140                | Measured                   |
 | Haiku  | 95                 | 570                 | Extrapolated (0.5x Sonnet) |
 
 **Important: these are order-of-magnitude estimates, not precise measurements.**
 
-- Sonnet factors are derived from Jegham et al. direct measurements. Opus and Haiku are extrapolated (no public data from Anthropic on per-model energy consumption).
+- Sonnet factors are derived from Jegham et al. direct measurements. Fable, Opus and Haiku are extrapolated (no public data from Anthropic on per-model energy consumption).
+- Sessions run on non-Anthropic models (e.g. local models behind `ANTHROPIC_BASE_URL`) are stored with their raw tokens but zero cost/CO2 and excluded from reports - a datacenter factor doesn't apply to them. Add patterns to `exclude_models` in `data/factors.json` to exclude more models by name.
 - Cache read tokens are counted at a reduced factor (default 0.08 of an input token, set in `data/factors.json`). A cached token skips prefill compute but still incurs decode-phase memory reads, so it is cheap but not free. This is an engineering estimate derived from the literature, not Anthropic's 0.1x billing ratio. See [METHODOLOGY.md](METHODOLOGY.md).
 - Carbon intensity uses AWS grid-average (0.287 kgCO2e/kWh), not real-time grid data.
 - Anthropic does not publish Scope 1, 2, or 3 emissions. These estimates are independent and based on academic research, not provider data.

--- a/data/factors.json
+++ b/data/factors.json
@@ -4,9 +4,13 @@
   "_source": "https://arxiv.org/abs/2505.09598",
   "_cache_read_factor": "Energy of a cache_read token as a fraction of an uncached input token. Engineering estimate (~0.08, defensible range 0.05-0.15) derived from the decode-phase KV re-read residual. NOT Anthropic's 0.1x billing ratio (a price, not energy). See METHODOLOGY.md.",
   "cache_read_factor": 0.08,
+  "_fable": "No published measurement for Fable 5 (claude-fable-5 / claude-mythos-5). Extrapolated from Opus by the list-price ratio (2x, $10/$50 vs $5/$25), same approach as the Opus 3x-Sonnet extrapolation.",
   "models": {
+    "fable": { "input": 1000, "output": 6000 },
     "opus": { "input": 500, "output": 3000 },
     "sonnet": { "input": 190, "output": 1140 },
     "haiku": { "input": 95, "output": 570 }
-  }
+  },
+  "_exclude_models": "Sessions whose model string does not contain 'claude' (e.g. local models served behind ANTHROPIC_BASE_URL) are always stored with cost_usd=0, co2_grams=0 and excluded=1, and left out of report aggregates. Add case-insensitive grep -E patterns here to exclude additional models by name.",
+  "exclude_models": []
 }

--- a/data/prices.json
+++ b/data/prices.json
@@ -1,8 +1,9 @@
 {
   "_units": "USD per million tokens — current Anthropic list price (pay-as-you-go API value).",
-  "_note": "Opus 4.6+ is 5/25 (the retired 4.0/4.1 was 15/75). cache_write = input x cache_write_multiplier (5-min TTL), cache_read = input x cache_read_multiplier. After editing, run scripts/recompute.sh to re-derive cost_usd for all raw-token rows without needing the (purged) JSONL.",
-  "_updated": "2026-06-05",
+  "_note": "Fable 5 (claude-fable-5 / claude-mythos-5) is 10/50. Opus 4.6+ is 5/25 (the retired 4.0/4.1 was 15/75). cache_write = input x cache_write_multiplier (5-min TTL), cache_read = input x cache_read_multiplier. After editing, run scripts/recompute.sh to re-derive cost_usd for all raw-token rows without needing the (purged) JSONL.",
+  "_updated": "2026-06-12",
   "models": {
+    "fable": { "input": 10, "output": 50 },
     "opus": { "input": 5, "output": 25 },
     "sonnet": { "input": 3, "output": 15 },
     "haiku": { "input": 1, "output": 5 }

--- a/scripts/backfill.sh
+++ b/scripts/backfill.sh
@@ -17,12 +17,15 @@ DB_PATH="${CLAUDE_CARBON_DB:-${HOME}/.claude/claude-carbon/carbon.db}"
 METHODOLOGY_VERSION=2
 
 # Ensure schema exists and is migrated (idempotent; safe on fresh or pre-existing DBs).
-sqlite3 "$DB_PATH" "CREATE TABLE IF NOT EXISTS sessions (session_id TEXT PRIMARY KEY, project TEXT, model TEXT, input_tokens INTEGER, output_tokens INTEGER, cache_read_tokens INTEGER DEFAULT 0, cache_creation_tokens INTEGER DEFAULT 0, cost_usd REAL, co2_grams REAL, started_at TEXT, ended_at TEXT, source TEXT DEFAULT 'live', methodology_version INTEGER DEFAULT 1); CREATE INDEX IF NOT EXISTS idx_sessions_year ON sessions(started_at);" 2>/dev/null || true
+sqlite3 "$DB_PATH" "CREATE TABLE IF NOT EXISTS sessions (session_id TEXT PRIMARY KEY, project TEXT, model TEXT, input_tokens INTEGER, output_tokens INTEGER, cache_read_tokens INTEGER DEFAULT 0, cache_creation_tokens INTEGER DEFAULT 0, cost_usd REAL, co2_grams REAL, started_at TEXT, ended_at TEXT, source TEXT DEFAULT 'live', methodology_version INTEGER DEFAULT 1, excluded INTEGER DEFAULT 0); CREATE INDEX IF NOT EXISTS idx_sessions_year ON sessions(started_at);" 2>/dev/null || true
 sqlite3 "$DB_PATH" "ALTER TABLE sessions ADD COLUMN cache_read_tokens INTEGER DEFAULT 0;" 2>/dev/null || true
 sqlite3 "$DB_PATH" "ALTER TABLE sessions ADD COLUMN cache_creation_tokens INTEGER DEFAULT 0;" 2>/dev/null || true
 sqlite3 "$DB_PATH" "ALTER TABLE sessions ADD COLUMN methodology_version INTEGER DEFAULT 1;" 2>/dev/null || true
+sqlite3 "$DB_PATH" "ALTER TABLE sessions ADD COLUMN excluded INTEGER DEFAULT 0;" 2>/dev/null || true
 
 # Load emission factors once (gCO2e per million tokens)
+FACTOR_FABLE_IN="$(jq -r '.models.fable.input // 1000' "$FACTORS_FILE")"
+FACTOR_FABLE_OUT="$(jq -r '.models.fable.output // 6000' "$FACTORS_FILE")"
 FACTOR_OPUS_IN="$(jq -r '.models.opus.input' "$FACTORS_FILE")"
 FACTOR_OPUS_OUT="$(jq -r '.models.opus.output' "$FACTORS_FILE")"
 FACTOR_SONNET_IN="$(jq -r '.models.sonnet.input' "$FACTORS_FILE")"
@@ -32,7 +35,11 @@ FACTOR_HAIKU_OUT="$(jq -r '.models.haiku.output' "$FACTORS_FILE")"
 # Energy of a cache_read token as a fraction of an uncached input token (see METHODOLOGY.md).
 CACHE_READ_FACTOR="$(jq -r '.cache_read_factor // 0.08' "$FACTORS_FILE")"
 
+# User-defined exclusion patterns (grep -E, case-insensitive), joined with |
+EXCLUDE_MODELS="$(jq -r '(.exclude_models // []) | join("|")' "$FACTORS_FILE" 2>/dev/null || true)"
+
 # Load pricing once (USD per million tokens, current Anthropic list price)
+PRICE_FABLE_IN="$(jq -r '.models.fable.input // 10' "$PRICES_FILE")"; PRICE_FABLE_OUT="$(jq -r '.models.fable.output // 50' "$PRICES_FILE")"
 PRICE_OPUS_IN="$(jq -r '.models.opus.input' "$PRICES_FILE")";     PRICE_OPUS_OUT="$(jq -r '.models.opus.output' "$PRICES_FILE")"
 PRICE_SONNET_IN="$(jq -r '.models.sonnet.input' "$PRICES_FILE")"; PRICE_SONNET_OUT="$(jq -r '.models.sonnet.output' "$PRICES_FILE")"
 PRICE_HAIKU_IN="$(jq -r '.models.haiku.input' "$PRICES_FILE")";   PRICE_HAIKU_OUT="$(jq -r '.models.haiku.output' "$PRICES_FILE")"
@@ -109,31 +116,42 @@ aggregate_jsonl() {
 # Helper: resolve model family from model string
 resolve_family() {
   local model="$1"
-  if echo "$model" | grep -qi "opus"; then echo "opus"
+  if echo "$model" | grep -qiE "fable|mythos"; then echo "fable"
+  elif echo "$model" | grep -qi "opus"; then echo "opus"
   elif echo "$model" | grep -qi "haiku"; then echo "haiku"
   else echo "sonnet"
   fi
 }
 
+# Helper: returns 0 when the model should be excluded from cost/CO2 accounting:
+# not an Anthropic Claude model (e.g. a local model behind ANTHROPIC_BASE_URL,
+# or the "<synthetic>" marker), or matching a user pattern in exclude_models.
+is_excluded_model() {
+  local model="$1"
+  if ! echo "$model" | grep -qi "claude"; then return 0; fi
+  if [ -n "$EXCLUDE_MODELS" ] && echo "$model" | grep -qiE "$EXCLUDE_MODELS"; then return 0; fi
+  return 1
+}
+
 # Helper: get factors and pricing for a model family
 get_factor_in() {
   case "$1" in
-    opus) echo "$FACTOR_OPUS_IN" ;; haiku) echo "$FACTOR_HAIKU_IN" ;; *) echo "$FACTOR_SONNET_IN" ;;
+    fable) echo "$FACTOR_FABLE_IN" ;; opus) echo "$FACTOR_OPUS_IN" ;; haiku) echo "$FACTOR_HAIKU_IN" ;; *) echo "$FACTOR_SONNET_IN" ;;
   esac
 }
 get_factor_out() {
   case "$1" in
-    opus) echo "$FACTOR_OPUS_OUT" ;; haiku) echo "$FACTOR_HAIKU_OUT" ;; *) echo "$FACTOR_SONNET_OUT" ;;
+    fable) echo "$FACTOR_FABLE_OUT" ;; opus) echo "$FACTOR_OPUS_OUT" ;; haiku) echo "$FACTOR_HAIKU_OUT" ;; *) echo "$FACTOR_SONNET_OUT" ;;
   esac
 }
 get_price_in() {
   case "$1" in
-    opus) echo "$PRICE_OPUS_IN" ;; haiku) echo "$PRICE_HAIKU_IN" ;; *) echo "$PRICE_SONNET_IN" ;;
+    fable) echo "$PRICE_FABLE_IN" ;; opus) echo "$PRICE_OPUS_IN" ;; haiku) echo "$PRICE_HAIKU_IN" ;; *) echo "$PRICE_SONNET_IN" ;;
   esac
 }
 get_price_out() {
   case "$1" in
-    opus) echo "$PRICE_OPUS_OUT" ;; haiku) echo "$PRICE_HAIKU_OUT" ;; *) echo "$PRICE_SONNET_OUT" ;;
+    fable) echo "$PRICE_FABLE_OUT" ;; opus) echo "$PRICE_OPUS_OUT" ;; haiku) echo "$PRICE_HAIKU_OUT" ;; *) echo "$PRICE_SONNET_OUT" ;;
   esac
 }
 
@@ -157,16 +175,22 @@ compute_co2_cost() {
     end
   ')"
 
-  family="$(resolve_family "$model_raw")"
-  fin="$(get_factor_in "$family")"
-  fout="$(get_factor_out "$family")"
-  pin="$(get_price_in "$family")"
-  pout="$(get_price_out "$family")"
+  if is_excluded_model "$model_raw"; then
+    # Non-Anthropic / user-excluded model: keep raw tokens, no cost/CO2 estimate
+    co2="0"
+    cost="0"
+  else
+    family="$(resolve_family "$model_raw")"
+    fin="$(get_factor_in "$family")"
+    fout="$(get_factor_out "$family")"
+    pin="$(get_price_in "$family")"
+    pout="$(get_price_out "$family")"
 
-  co2="$(echo "$it $cw $cr $out $fin $fout $CACHE_READ_FACTOR" | LC_ALL=C awk \
-    '{printf "%.4f", (($1 + $2) * $5 + $3 * ($5 * $7) + $4 * $6) / 1000000}')"
-  cost="$(echo "$it $cw $cr $out $pin $pout $CACHE_WRITE_MULT $CACHE_READ_MULT" | LC_ALL=C awk \
-    '{printf "%.6f", ($1 * $5 + $2 * ($5 * $7) + $3 * ($5 * $8) + $4 * $6) / 1000000}')"
+    co2="$(echo "$it $cw $cr $out $fin $fout $CACHE_READ_FACTOR" | LC_ALL=C awk \
+      '{printf "%.4f", (($1 + $2) * $5 + $3 * ($5 * $7) + $4 * $6) / 1000000}')"
+    cost="$(echo "$it $cw $cr $out $pin $pout $CACHE_WRITE_MULT $CACHE_READ_MULT" | LC_ALL=C awk \
+      '{printf "%.6f", ($1 * $5 + $2 * ($5 * $7) + $3 * ($5 * $8) + $4 * $6) / 1000000}')"
+  fi
 
   total_input="$(echo "$it $cw" | LC_ALL=C awk '{printf "%d", $1 + $2}')"
   echo "$total_input $cw $cr $out $co2 $cost"
@@ -255,6 +279,10 @@ while IFS= read -r JSONL_FILE; do
     end
   ')"
 
+  # Excluded flag (based on the session's dominant model)
+  EXCLUDED=0
+  if is_excluded_model "$MODEL_RAW"; then EXCLUDED=1; fi
+
   # Sanitize strings for SQL (escape single quotes)
   PROJECT="${PROJECT//\'/\'\'}"
   MODEL_RAW="${MODEL_RAW//\'/\'\'}"
@@ -262,7 +290,7 @@ while IFS= read -r JSONL_FILE; do
   LAST_TS="${LAST_TS//\'/\'\'}"
 
   # Insert into DB
-  sqlite3 "$DB_PATH" "INSERT OR IGNORE INTO sessions (session_id, project, model, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens, cost_usd, co2_grams, started_at, ended_at, source, methodology_version) VALUES ('${SESSION_ID}', '${PROJECT}', '${MODEL_RAW}', ${TOTAL_INPUT}, ${OUTPUT_TOKENS}, ${CACHE_READ}, ${CACHE_CREATION}, ${COST_USD}, ${CO2_G}, '${FIRST_TS}', '${LAST_TS}', 'backfill', ${METHODOLOGY_VERSION});" 2>/dev/null || { ERRORS=$((ERRORS + 1)); continue; }
+  sqlite3 "$DB_PATH" "INSERT OR IGNORE INTO sessions (session_id, project, model, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens, cost_usd, co2_grams, started_at, ended_at, source, methodology_version, excluded) VALUES ('${SESSION_ID}', '${PROJECT}', '${MODEL_RAW}', ${TOTAL_INPUT}, ${OUTPUT_TOKENS}, ${CACHE_READ}, ${CACHE_CREATION}, ${COST_USD}, ${CO2_G}, '${FIRST_TS}', '${LAST_TS}', 'backfill', ${METHODOLOGY_VERSION}, ${EXCLUDED});" 2>/dev/null || { ERRORS=$((ERRORS + 1)); continue; }
 
   ADDED=$((ADDED + 1))
 

--- a/scripts/generate-report.sh
+++ b/scripts/generate-report.sh
@@ -52,11 +52,11 @@ done
 
 SINCE_LABEL="$SINCE_LABEL_FR"
 
-# Build SQL WHERE clause
+# Build SQL WHERE clause (always filters out excluded sessions, e.g. non-Anthropic models)
 if [ -n "$SINCE" ]; then
-  WHERE="WHERE started_at >= '${SINCE}'"
+  WHERE="WHERE COALESCE(excluded, 0) = 0 AND started_at >= '${SINCE}'"
 else
-  WHERE=""
+  WHERE="WHERE COALESCE(excluded, 0) = 0"
 fi
 
 # ── Deps check ──────────────────────────────────────────────
@@ -73,6 +73,9 @@ if [ ! -f "$DB_PATH" ]; then
 fi
 
 mkdir -p "$EXPORT_DIR"
+
+# Ensure the excluded column exists on pre-existing DBs (idempotent)
+sqlite3 "$DB_PATH" "ALTER TABLE sessions ADD COLUMN excluded INTEGER DEFAULT 0;" 2>/dev/null || true
 
 # ── Query DB ────────────────────────────────────────────────
 echo "Querying carbon.db (since ${SINCE_LABEL})..."

--- a/scripts/persist-session.sh
+++ b/scripts/persist-session.sh
@@ -21,8 +21,11 @@ METHODOLOGY_VERSION=2
 sqlite3 "$DB_PATH" "ALTER TABLE sessions ADD COLUMN cache_read_tokens INTEGER DEFAULT 0;" 2>/dev/null || true
 sqlite3 "$DB_PATH" "ALTER TABLE sessions ADD COLUMN cache_creation_tokens INTEGER DEFAULT 0;" 2>/dev/null || true
 sqlite3 "$DB_PATH" "ALTER TABLE sessions ADD COLUMN methodology_version INTEGER DEFAULT 1;" 2>/dev/null || true
+sqlite3 "$DB_PATH" "ALTER TABLE sessions ADD COLUMN excluded INTEGER DEFAULT 0;" 2>/dev/null || true
 
 # Load emission factors once
+FACTOR_FABLE_IN="$(jq -r '.models.fable.input // 1000' "$FACTORS_FILE" 2>/dev/null)" || FACTOR_FABLE_IN="1000"
+FACTOR_FABLE_OUT="$(jq -r '.models.fable.output // 6000' "$FACTORS_FILE" 2>/dev/null)" || FACTOR_FABLE_OUT="6000"
 FACTOR_OPUS_IN="$(jq -r '.models.opus.input' "$FACTORS_FILE" 2>/dev/null)" || exit 0
 FACTOR_OPUS_OUT="$(jq -r '.models.opus.output' "$FACTORS_FILE" 2>/dev/null)" || exit 0
 FACTOR_SONNET_IN="$(jq -r '.models.sonnet.input' "$FACTORS_FILE" 2>/dev/null)" || exit 0
@@ -34,6 +37,8 @@ CACHE_READ_FACTOR="$(jq -r '.cache_read_factor // 0.08' "$FACTORS_FILE" 2>/dev/n
 
 # Load pricing once (USD per million tokens, current Anthropic list price).
 # The Stop hook doesn't provide the actual billed cost, so we estimate the API list value.
+PRICE_FABLE_IN="$(jq -r '.models.fable.input // 10' "$PRICES_FILE" 2>/dev/null)" || PRICE_FABLE_IN="10"
+PRICE_FABLE_OUT="$(jq -r '.models.fable.output // 50' "$PRICES_FILE" 2>/dev/null)" || PRICE_FABLE_OUT="50"
 PRICE_OPUS_IN="$(jq -r '.models.opus.input' "$PRICES_FILE" 2>/dev/null)" || PRICE_OPUS_IN="5"
 PRICE_OPUS_OUT="$(jq -r '.models.opus.output' "$PRICES_FILE" 2>/dev/null)" || PRICE_OPUS_OUT="25"
 PRICE_SONNET_IN="$(jq -r '.models.sonnet.input' "$PRICES_FILE" 2>/dev/null)" || PRICE_SONNET_IN="3"
@@ -42,6 +47,19 @@ PRICE_HAIKU_IN="$(jq -r '.models.haiku.input' "$PRICES_FILE" 2>/dev/null)" || PR
 PRICE_HAIKU_OUT="$(jq -r '.models.haiku.output' "$PRICES_FILE" 2>/dev/null)" || PRICE_HAIKU_OUT="5"
 CACHE_WRITE_MULT="$(jq -r '.cache_write_multiplier // 1.25' "$PRICES_FILE" 2>/dev/null)" || CACHE_WRITE_MULT="1.25"
 CACHE_READ_MULT="$(jq -r '.cache_read_multiplier // 0.1' "$PRICES_FILE" 2>/dev/null)" || CACHE_READ_MULT="0.1"
+
+# User-defined exclusion patterns (grep -E, case-insensitive), joined with |
+EXCLUDE_MODELS="$(jq -r '(.exclude_models // []) | join("|")' "$FACTORS_FILE" 2>/dev/null)" || EXCLUDE_MODELS=""
+
+# Helper: returns 0 when the model should be excluded from cost/CO2 accounting:
+# not an Anthropic Claude model (e.g. a local model behind ANTHROPIC_BASE_URL,
+# or the "<synthetic>" marker), or matching a user pattern in exclude_models.
+is_excluded_model() {
+  local model="$1"
+  if ! echo "$model" | grep -qi "claude"; then return 0; fi
+  if [ -n "$EXCLUDE_MODELS" ] && echo "$model" | grep -qiE "$EXCLUDE_MODELS"; then return 0; fi
+  return 1
+}
 
 # Read stdin
 INPUT="$(cat 2>/dev/null)" || exit 0
@@ -120,11 +138,21 @@ compute_co2() {
   out="$(echo "$agg" | jq -r '.output_tokens // 0')"
   model="$(echo "$agg" | jq -r '.models | if length == 0 then "claude-sonnet" else group_by(.) | sort_by(-length) | first | first end')"
 
+  total_input="$(echo "$it $cw" | LC_ALL=C awk '{printf "%d", $1 + $2}')"
+
+  if is_excluded_model "$model"; then
+    # Non-Anthropic / user-excluded model: keep raw tokens, no cost/CO2 estimate
+    echo "$total_input $cw $cr $out 0 0"
+    return 0
+  fi
+
   family="sonnet"
+  echo "$model" | grep -qiE "fable|mythos" && family="fable"
   echo "$model" | grep -qi "opus" && family="opus"
   echo "$model" | grep -qi "haiku" && family="haiku"
 
   case "$family" in
+    fable) fin="$FACTOR_FABLE_IN"; fout="$FACTOR_FABLE_OUT"; pin="$PRICE_FABLE_IN"; pout="$PRICE_FABLE_OUT" ;;
     opus)  fin="$FACTOR_OPUS_IN"; fout="$FACTOR_OPUS_OUT"; pin="$PRICE_OPUS_IN"; pout="$PRICE_OPUS_OUT" ;;
     haiku) fin="$FACTOR_HAIKU_IN"; fout="$FACTOR_HAIKU_OUT"; pin="$PRICE_HAIKU_IN"; pout="$PRICE_HAIKU_OUT" ;;
     *)     fin="$FACTOR_SONNET_IN"; fout="$FACTOR_SONNET_OUT"; pin="$PRICE_SONNET_IN"; pout="$PRICE_SONNET_OUT" ;;
@@ -186,6 +214,10 @@ PROJECT="$(basename "$CURRENT_DIR" 2>/dev/null)" || PROJECT="unknown"
 # Current timestamp
 NOW="$(date -u +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null)" || NOW=""
 
+# Excluded flag (based on the session's dominant model)
+EXCLUDED=0
+if is_excluded_model "$MODEL_RAW"; then EXCLUDED=1; fi
+
 # Sanitize strings for SQL
 SESSION_ID="${SESSION_ID//\'/\'\'}"
 PROJECT="${PROJECT//\'/\'\'}"
@@ -193,6 +225,6 @@ MODEL_RAW="${MODEL_RAW//\'/\'\'}"
 NOW="${NOW//\'/\'\'}"
 
 # INSERT OR REPLACE into sessions (source='live', cost = theoretical API list price)
-sqlite3 "$DB_PATH" "INSERT OR REPLACE INTO sessions (session_id, project, model, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens, cost_usd, co2_grams, started_at, ended_at, source, methodology_version) VALUES ('${SESSION_ID}', '${PROJECT}', '${MODEL_RAW}', ${INPUT_TOKENS}, ${OUTPUT_TOKENS}, ${CACHE_READ}, ${CACHE_CREATION}, ${COST_USD}, ${CO2_G}, COALESCE((SELECT started_at FROM sessions WHERE session_id='${SESSION_ID}'), '${NOW}'), '${NOW}', 'live', ${METHODOLOGY_VERSION});" 2>/dev/null || true
+sqlite3 "$DB_PATH" "INSERT OR REPLACE INTO sessions (session_id, project, model, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens, cost_usd, co2_grams, started_at, ended_at, source, methodology_version, excluded) VALUES ('${SESSION_ID}', '${PROJECT}', '${MODEL_RAW}', ${INPUT_TOKENS}, ${OUTPUT_TOKENS}, ${CACHE_READ}, ${CACHE_CREATION}, ${COST_USD}, ${CO2_G}, COALESCE((SELECT started_at FROM sessions WHERE session_id='${SESSION_ID}'), '${NOW}'), '${NOW}', 'live', ${METHODOLOGY_VERSION}, ${EXCLUDED});" 2>/dev/null || true
 
 exit 0

--- a/scripts/recompute.sh
+++ b/scripts/recompute.sh
@@ -22,12 +22,14 @@ DB_PATH="${CLAUDE_CARBON_DB:-${HOME}/.claude/claude-carbon/carbon.db}"
 [ -f "$DB_PATH" ] || { echo "No database at ${DB_PATH}" >&2; exit 1; }
 
 # Emission factors (gCO2e per million tokens) + cache_read energy fraction
+F_FAB_IN="$(jq -r '.models.fable.input // 1000' "$FACTORS_FILE")"; F_FAB_OUT="$(jq -r '.models.fable.output // 6000' "$FACTORS_FILE")"
 F_OPUS_IN="$(jq -r '.models.opus.input' "$FACTORS_FILE")";    F_OPUS_OUT="$(jq -r '.models.opus.output' "$FACTORS_FILE")"
 F_SON_IN="$(jq -r '.models.sonnet.input' "$FACTORS_FILE")";   F_SON_OUT="$(jq -r '.models.sonnet.output' "$FACTORS_FILE")"
 F_HAI_IN="$(jq -r '.models.haiku.input' "$FACTORS_FILE")";    F_HAI_OUT="$(jq -r '.models.haiku.output' "$FACTORS_FILE")"
 CRF="$(jq -r '.cache_read_factor // 0.08' "$FACTORS_FILE")"
 
 # Prices (USD per million tokens) + cache multipliers
+P_FAB_IN="$(jq -r '.models.fable.input // 10' "$PRICES_FILE")"; P_FAB_OUT="$(jq -r '.models.fable.output // 50' "$PRICES_FILE")"
 P_OPUS_IN="$(jq -r '.models.opus.input' "$PRICES_FILE")";     P_OPUS_OUT="$(jq -r '.models.opus.output' "$PRICES_FILE")"
 P_SON_IN="$(jq -r '.models.sonnet.input' "$PRICES_FILE")";    P_SON_OUT="$(jq -r '.models.sonnet.output' "$PRICES_FILE")"
 P_HAI_IN="$(jq -r '.models.haiku.input' "$PRICES_FILE")";     P_HAI_OUT="$(jq -r '.models.haiku.output' "$PRICES_FILE")"
@@ -46,15 +48,16 @@ update_family() {
     UPDATE sessions SET
       co2_grams = (input_tokens*${fin} + cache_read_tokens*(${fin}*${CRF}) + output_tokens*${fout}) / 1000000.0,
       cost_usd  = ((input_tokens - cache_creation_tokens)*${pin} + cache_creation_tokens*(${pin}*${CW_MULT}) + cache_read_tokens*(${pin}*${CR_MULT}) + output_tokens*${pout}) / 1000000.0
-    WHERE methodology_version >= 2 AND ${where};
+    WHERE methodology_version >= 2 AND COALESCE(excluded, 0) = 0 AND ${where};
   "
 }
 
+update_family "(model LIKE '%fable%' OR model LIKE '%mythos%')" "$F_FAB_IN" "$F_FAB_OUT" "$P_FAB_IN" "$P_FAB_OUT"
 update_family "model LIKE '%opus%'"  "$F_OPUS_IN" "$F_OPUS_OUT" "$P_OPUS_IN" "$P_OPUS_OUT"
 update_family "model LIKE '%haiku%'" "$F_HAI_IN"  "$F_HAI_OUT"  "$P_HAI_IN"  "$P_HAI_OUT"
-update_family "model NOT LIKE '%opus%' AND model NOT LIKE '%haiku%'" "$F_SON_IN" "$F_SON_OUT" "$P_SON_IN" "$P_SON_OUT"
+update_family "model NOT LIKE '%fable%' AND model NOT LIKE '%mythos%' AND model NOT LIKE '%opus%' AND model NOT LIKE '%haiku%'" "$F_SON_IN" "$F_SON_OUT" "$P_SON_IN" "$P_SON_OUT"
 
-RECOMPUTED="$(sqlite3 "$DB_PATH" "SELECT COUNT(*) FROM sessions WHERE methodology_version >= 2;")"
+RECOMPUTED="$(sqlite3 "$DB_PATH" "SELECT COUNT(*) FROM sessions WHERE methodology_version >= 2 AND COALESCE(excluded, 0) = 0;")"
 LEGACY="$(sqlite3 "$DB_PATH" "SELECT COUNT(*) FROM sessions WHERE methodology_version IS NULL OR methodology_version < 2;")"
 TOTAL_COST="$(sqlite3 "$DB_PATH" "SELECT printf('%.0f', COALESCE(SUM(cost_usd),0)) FROM sessions;")"
 TOTAL_CO2_KG="$(sqlite3 "$DB_PATH" "SELECT printf('%.0f', COALESCE(SUM(co2_grams),0)/1000.0) FROM sessions;")"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -48,7 +48,8 @@ CREATE TABLE IF NOT EXISTS sessions (
   started_at TEXT,
   ended_at TEXT,
   source TEXT DEFAULT 'live',
-  methodology_version INTEGER DEFAULT 1
+  methodology_version INTEGER DEFAULT 1,
+  excluded INTEGER DEFAULT 0
 );
 CREATE INDEX IF NOT EXISTS idx_sessions_year ON sessions(started_at);
 SQL
@@ -57,6 +58,7 @@ SQL
 sqlite3 "$DB_PATH" "ALTER TABLE sessions ADD COLUMN cache_read_tokens INTEGER DEFAULT 0;" 2>/dev/null || true
 sqlite3 "$DB_PATH" "ALTER TABLE sessions ADD COLUMN cache_creation_tokens INTEGER DEFAULT 0;" 2>/dev/null || true
 sqlite3 "$DB_PATH" "ALTER TABLE sessions ADD COLUMN methodology_version INTEGER DEFAULT 1;" 2>/dev/null || true
+sqlite3 "$DB_PATH" "ALTER TABLE sessions ADD COLUMN excluded INTEGER DEFAULT 0;" 2>/dev/null || true
 
 echo "  Schema created."
 

--- a/scripts/statusline.sh
+++ b/scripts/statusline.sh
@@ -24,15 +24,23 @@ PROJECT="$(basename "$CURRENT_DIR")"
 
 # Resolve model family
 MODEL_FAMILY="sonnet"
-if echo "$MODEL_ID" | grep -qi "opus"; then
+if echo "$MODEL_ID" | grep -qiE "fable|mythos"; then
+  MODEL_FAMILY="fable"
+elif echo "$MODEL_ID" | grep -qi "opus"; then
   MODEL_FAMILY="opus"
 elif echo "$MODEL_ID" | grep -qi "haiku"; then
   MODEL_FAMILY="haiku"
 fi
 
-# Load emission factors
-FACTOR_IN="$(jq -r ".models.${MODEL_FAMILY}.input" "$FACTORS_FILE")"
-FACTOR_OUT="$(jq -r ".models.${MODEL_FAMILY}.output" "$FACTORS_FILE")"
+# Load emission factors (zero for non-Anthropic models, e.g. local models
+# behind ANTHROPIC_BASE_URL — a datacenter factor doesn't apply to them)
+if echo "$MODEL_ID" | grep -qi "claude"; then
+  FACTOR_IN="$(jq -r ".models.${MODEL_FAMILY}.input // 190" "$FACTORS_FILE")"
+  FACTOR_OUT="$(jq -r ".models.${MODEL_FAMILY}.output // 1140" "$FACTORS_FILE")"
+else
+  FACTOR_IN="0"
+  FACTOR_OUT="0"
+fi
 
 # Calculate CO2 in grams: (input * factor_in + output * factor_out) / 1_000_000
 CO2_G="$(echo "$INPUT_TOKENS $FACTOR_IN $OUTPUT_TOKENS $FACTOR_OUT" | LC_ALL=C awk '{printf "%.0f", ($1 * $2 + $3 * $4) / 1000000}')"

--- a/skills/carbon-report/SKILL.md
+++ b/skills/carbon-report/SKILL.md
@@ -23,16 +23,21 @@ fi
 CURRENT_YEAR="$(date +%Y)"
 TODAY="$(date +%Y-%m-%d)"
 
+# Ensure the excluded column exists on pre-existing DBs (idempotent).
+# Excluded sessions (non-Anthropic models, e.g. local models) are left out of all aggregates.
+sqlite3 "$DB_PATH" "ALTER TABLE sessions ADD COLUMN excluded INTEGER DEFAULT 0;" 2>/dev/null || true
+NOT_EXCLUDED="COALESCE(excluded, 0) = 0"
+
 # --- Aggregates ---
-TODAY_CO2="$(sqlite3 "$DB_PATH" "SELECT COALESCE(SUM(co2_grams), 0) FROM sessions WHERE started_at LIKE '${TODAY}%';" | awk '{printf "%.1f", $1}')"
-TODAY_SESSIONS="$(sqlite3 "$DB_PATH" "SELECT COUNT(*) FROM sessions WHERE started_at LIKE '${TODAY}%';")"
+TODAY_CO2="$(sqlite3 "$DB_PATH" "SELECT COALESCE(SUM(co2_grams), 0) FROM sessions WHERE ${NOT_EXCLUDED} AND started_at LIKE '${TODAY}%';" | awk '{printf "%.1f", $1}')"
+TODAY_SESSIONS="$(sqlite3 "$DB_PATH" "SELECT COUNT(*) FROM sessions WHERE ${NOT_EXCLUDED} AND started_at LIKE '${TODAY}%';")"
 
-YEAR_CO2="$(sqlite3 "$DB_PATH" "SELECT COALESCE(SUM(co2_grams), 0) FROM sessions WHERE started_at LIKE '${CURRENT_YEAR}%';" | awk '{printf "%.1f", $1}')"
-YEAR_SESSIONS="$(sqlite3 "$DB_PATH" "SELECT COUNT(*) FROM sessions WHERE started_at LIKE '${CURRENT_YEAR}%';")"
+YEAR_CO2="$(sqlite3 "$DB_PATH" "SELECT COALESCE(SUM(co2_grams), 0) FROM sessions WHERE ${NOT_EXCLUDED} AND started_at LIKE '${CURRENT_YEAR}%';" | awk '{printf "%.1f", $1}')"
+YEAR_SESSIONS="$(sqlite3 "$DB_PATH" "SELECT COUNT(*) FROM sessions WHERE ${NOT_EXCLUDED} AND started_at LIKE '${CURRENT_YEAR}%';")"
 
-ALL_CO2="$(sqlite3 "$DB_PATH" "SELECT COALESCE(SUM(co2_grams), 0) FROM sessions;" | awk '{printf "%.1f", $1}')"
-ALL_SESSIONS="$(sqlite3 "$DB_PATH" "SELECT COUNT(*) FROM sessions;")"
-ALL_COST="$(sqlite3 "$DB_PATH" "SELECT COALESCE(SUM(cost_usd), 0) FROM sessions;" | awk '{printf "%.2f", $1}')"
+ALL_CO2="$(sqlite3 "$DB_PATH" "SELECT COALESCE(SUM(co2_grams), 0) FROM sessions WHERE ${NOT_EXCLUDED};" | awk '{printf "%.1f", $1}')"
+ALL_SESSIONS="$(sqlite3 "$DB_PATH" "SELECT COUNT(*) FROM sessions WHERE ${NOT_EXCLUDED};")"
+ALL_COST="$(sqlite3 "$DB_PATH" "SELECT COALESCE(SUM(cost_usd), 0) FROM sessions WHERE ${NOT_EXCLUDED};" | awk '{printf "%.2f", $1}')"
 
 # --- Equivalences (all-time total) ---
 KM_CAR="$(echo "$ALL_CO2" | awk '{printf "%.0f", $1 / 120}')"
@@ -43,6 +48,7 @@ KM_TGV="$(echo "$ALL_CO2" | awk '{printf "%.0f", $1 / 2.4}')"
 TOP5="$(sqlite3 -separator '|' "$DB_PATH" \
   "SELECT DATE(started_at), project, ROUND(co2_grams, 2), model, ROUND(cost_usd, 4)
    FROM sessions
+   WHERE ${NOT_EXCLUDED}
    ORDER BY co2_grams DESC
    LIMIT 5;")"
 
@@ -50,6 +56,7 @@ TOP5="$(sqlite3 -separator '|' "$DB_PATH" \
 BY_PROJECT="$(sqlite3 -separator '|' "$DB_PATH" \
   "SELECT project, ROUND(SUM(co2_grams), 2), COUNT(*), ROUND(SUM(cost_usd), 4)
    FROM sessions
+   WHERE ${NOT_EXCLUDED}
    GROUP BY project
    ORDER BY SUM(co2_grams) DESC;")"
 


### PR DESCRIPTION
## Summary
- **Exclude non-Anthropic models** (#7): sessions whose dominant model string doesn't contain `claude` (local models behind `ANTHROPIC_BASE_URL`, `<synthetic>`) are stored with raw tokens but zero cost/CO2 and a new `excluded` column, and filtered out of all reports. Statusline shows 0g for them. User-configurable `exclude_models` pattern list in `data/factors.json`. Raw tokens are preserved so excluded rows can be re-priced by `recompute.sh` if local-model factors are ever added.
- **Fable 5 family**: `claude-fable-5` / `claude-mythos-5` fell into the Sonnet fallback of `resolve_family`, under-costing by 70%. New `fable` family across backfill, persist-session, recompute and statusline: $10/$50 per Mtok (current Anthropic list price), emission factors 1000/6000 gCO2e/Mtok extrapolated from Opus by the 2x price ratio (no published measurement; documented in METHODOLOGY.md).

Fixes #7

## Test plan
- [x] Backfill on temp DB: fable 1M in + 1M out = $60.00 / 7000g; `qwen2.5-coder-local` stored with excluded=1, $0, 0g
- [x] Stop hook on temp DB: fable 2M in + 1M out = $70.00 / 8000g; `llama-3-70b` excluded
- [x] `/carbon-report` script: aggregates count only non-excluded sessions ($130, 2 sessions)
- [x] `recompute.sh`: skips excluded rows, totals unchanged
- [x] Statusline: Fable 5 at 1M input shows 1.0kg CO2; local model shows 0g
- [x] `bash -n` on all modified scripts; `jq .` on both JSON configs

🤖 Generated with [Claude Code](https://claude.com/claude-code)