### PR TITLE
feat: recalibrate emission factors (Jegham v6) + EUR + self-update flow

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
         "url": "https://github.com/gwittebolle/claude-carbon.git"
       },
       "description": "Track the carbon footprint of your Claude Code sessions",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "author": {
         "name": "Gaetan Wittebolle"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-carbon",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Track the carbon footprint of your Claude Code sessions",
   "author": {
     "name": "Gaetan Wittebolle",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## 2026-06-22
+
+### feat: "update available" notice, one-command `/carbon-update`, and auto re-price on update
+
+Existing installs had no way to know a new version shipped, and updating was a manual curl re-run that `git pull --ff-only` would break for anyone who had edited `data/factors.json` (which the README invites). Added a full update flow:
+
+- **Notice**: a backgrounded, once-a-day version check (`scripts/check-update.sh`, run detached from the SessionStart hook) compares the local vs remote `plugin.json` version and writes a cached flag. The status line reads that flag locally (no network on the hot path) and shows a discreet `⬆ /carbon-update` when behind, with a 7-day staleness gate. Opt out via `CLAUDE_CARBON_NO_UPDATE_NOTIFIER=1`. Marketplace-cache installs are skipped (they use Claude Code's native auto-update).
+- **Update**: a `/carbon-update` slash command (and a hardened `install.sh`) run `scripts/update.sh`, a dirty-safe `git pull` that stashes only the two user-editable data files and, on conflict, preserves the user's version to `*.local.bak`.
+- **Recompute on update**: after a pull, history is re-priced with the new factors automatically. `recompute.sh` now defaults to **CO2-only** (idempotent, no mixed-model cost drift); cost re-pricing is opt-in via `--with-cost`. Added a 5s SQLite busy-timeout (`sqlite3 -cmd ".timeout 5000"`) so a concurrent Stop-hook write doesn't fail the recompute, and the recompute now refuses non-numeric config values (they are interpolated into SQL).
+- Bumped the plugin version to **1.1.0** (`plugin.json` + `marketplace.json`) so marketplace users are offered the update.
+
+### Refine emission factors and pricing to the best available data to date (multi-source, cross-validated)
+
+Triangulated the per-model CO2 factors and Anthropic pricing across independent sources (Jegham et al. v6 empirical AWS measurements, EcoLogits parametric LCA, third-party inference-energy studies, AWS regional grid data), with adversarial verification of the load-bearing numbers.
+
+- CO2 (gCO2e/Mtok, usage-only, AWS region grid 0.287): **Sonnet 39/826** - a 3-point OLS fit to Jegham v6's three measured Claude 3.7 Sonnet energies (0.950 / 2.989 / 5.671 Wh), cross-validated by EcoLogits which brackets the same range. **Opus 78/1652** (2x Sonnet): the current EcoLogits Opus 4.5+ parameter ratio and the Anthropic price ratio both imply ~1.7-2x, replacing the earlier 3x; honest band 2x-5x. **Haiku 20/413** (0.5x). **Fable 156/3304** (2x Opus). Bands and unmeasured-extrapolation caveats are documented in `METHODOLOGY.md`.
+- Relabeled the 0.287 kgCO2e/kWh carbon intensity as the AWS region grid (location-based), not a "US average" (the US average is ~380); kept 0.287 as the Jegham-consistent basis.
+- Pricing: all USD list prices reconfirmed current (Opus $5/$25, Sonnet $3/$15, Haiku $1/$5, Fable $10/$50; cache write 1.25x 5-min tier, read 0.1x) - no drift. Added `eur_per_usd` (ECB reference rate 2026-06-22, 0.8729) for EUR display, and documented the 2x 1-hour cache-write tier.
+
+These remain order-of-magnitude estimates and will keep being refined as measurements improve. Updated `data/factors.json`, `data/prices.json`, script fallbacks, `METHODOLOGY.md`, `README.md` and the golden vectors. Run `scripts/recompute.sh` to re-price stored rows.
+
+### docs: note terminal/IDE-only compatibility in README
+
+The status line and shell hooks only run in the Claude Code terminal CLI and IDE extensions, not the web (claude.ai/code) or desktop app. Added an explicit note under the install steps so users on the app don't expect CO2 tracking there.
+
 ## 2026-06-12
 
 ### feat: exclude non-Anthropic models from cost/CO2 accounting (#7)

--- a/METHODOLOGY.md
+++ b/METHODOLOGY.md
@@ -6,10 +6,20 @@ Emissions are estimated from token counts using per-token factors derived from p
 
 ## Source
 
-Jegham et al. (2025), "Measuring the Carbon Footprint of AI Inference"
+Jegham et al. (2025), "How Hungry is AI? Benchmarking the Energy, Water, and Carbon Footprint of LLM Inference" (v6)
 [arxiv.org/abs/2505.09598](https://arxiv.org/abs/2505.09598)
 
-The paper measures inference energy consumption on AWS infrastructure for a range of models, then converts to CO2e using grid-average carbon intensity.
+The paper measures inference energy consumption on AWS infrastructure for a range of models, then converts to CO2e using grid-average carbon intensity. For Claude 3.7 Sonnet it reports three per-query energies (Table 4, PUE included): **0.950 Wh** (100 input / 300 output), **2.989 Wh** (1k / 1k) and **5.671 Wh** (10k input / 1.5k output).
+
+### Deriving the Sonnet input/output factors
+
+The three measured points are fit with an ordinary least-squares regression through the origin in (energy per input token, energy per output token), matching the per-token model below (no per-query constant). That gives ~1.35e-4 Wh per input token and ~2.88e-3 Wh per output token. At CIF 0.287 gCO2e/Wh (= 0.287 kgCO2e/kWh) that is **~39 gCO2e/Mtok input** and **~826 gCO2e/Mtok output**, a marginal ratio of ~21:1. The fit matches the two high-token configurations (1k/1k, 10k/1.5k) to within 1%, the regime real Claude Code sessions live in.
+
+These are the best available data to date and will keep being refined as measurements improve. Earlier releases used 190/1140, calibrated against an earlier revision of the same preprint; the move to v6's three measured points refines that.
+
+### Cross-validation against EcoLogits
+
+[EcoLogits](https://ecologits.ai) (GenAI Impact / Data For Good) estimates inference impact by a completely independent route: model parameter counts plus a full lifecycle model, rather than measured AWS telemetry. Its estimate for Claude 3.7 Sonnet brackets **~565-1385 gCO2e/Mtok output** (parameter range, USA grid, full lifecycle), with a usage-only central value near ~630. The Jegham-derived **826** sits inside that band. Two unrelated methodologies agreeing is strong corroboration. Note one structural difference: EcoLogits charges zero energy to input tokens, whereas Jegham's measurements show a small but real input cost (the 10k-input query consumes more), which this tool keeps via the input factor.
 
 ## Formula
 
@@ -25,34 +35,37 @@ Factors are in gCO2e per million tokens. `cache_write_tokens` (`cache_creation_i
 
 ## Infrastructure parameters
 
-| Parameter | Value            | Description                                      |
-| --------- | ---------------- | ------------------------------------------------ |
-| PUE       | 1.14             | AWS datacenter power usage effectiveness         |
-| CIF       | 0.287 kgCO2e/kWh | Carbon intensity factor (US grid average)        |
-| WUE       | 0.18 L/kWh       | Water usage effectiveness (not used in CO2 calc) |
+| Parameter      | Value            | Description                                                                   |
+| -------------- | ---------------- | ----------------------------------------------------------------------------- |
+| PUE            | 1.14             | AWS datacenter power usage effectiveness                                      |
+| CIF            | 0.287 kgCO2e/kWh | AWS region grid CIF, location-based (Jegham et al.); US average is ~380 g/kWh |
+| WUE (on-site)  | 0.18 L/kWh       | Water for datacenter cooling (not used in CO2 calc)                           |
+| WUE (off-site) | 5.11 L/kWh       | Water for electricity generation (not used in CO2 calc)                       |
 
 ## Per-model factors (gCO2e per million tokens)
 
-| Model family | Input | Output | Source                     |
-| ------------ | ----- | ------ | -------------------------- |
-| Fable        | 1000  | 6000   | Extrapolated (2x Opus)     |
-| Opus         | 500   | 3000   | Extrapolated (3x Sonnet)   |
-| Sonnet       | 190   | 1140   | Measured (Jegham et al.)   |
-| Haiku        | 95    | 570    | Extrapolated (0.5x Sonnet) |
+| Model family | Input | Output | Source                         |
+| ------------ | ----- | ------ | ------------------------------ |
+| Fable        | 156   | 3304   | Extrapolated (2x Opus)         |
+| Opus         | 78    | 1652   | Extrapolated (2x Sonnet)       |
+| Sonnet       | 39    | 826    | 3-point fit (Jegham et al. v6) |
+| Haiku        | 20    | 413    | Extrapolated (0.5x Sonnet)     |
 
 ## Why input and output factors differ
 
-Output tokens are ~6x more expensive than input tokens in terms of compute. During prefill (input processing), the model processes all input tokens in parallel. During decoding (output generation), each token requires a full forward pass through the model sequentially. This autoregressive step dominates energy consumption.
+Output tokens are far more energy-intensive per token than input tokens. During prefill (input processing), the model processes all input tokens in parallel in one batched forward pass. During decoding (output generation), each token requires its own sequential forward pass through the model. This autoregressive step dominates energy consumption.
+
+The exact ratio is not assumed, it is recovered from the three measured Sonnet points (see Deriving the Sonnet input/output factors above): the fit yields a marginal output:input ratio of ~21:1 (826 vs 39 gCO2e/Mtok). A large input (long context) adds little energy relative to the same number of generated tokens, which a flat low ratio would miss.
 
 ## Why Fable, Opus and Haiku are extrapolated
 
 The Jegham paper measured Sonnet-class models directly. The other families are estimated by scaling:
 
+- Opus = 2x Sonnet. The current EcoLogits parameter assumptions for Opus 4.5+ (670B vs Sonnet 4.x 440B, active ~133B vs ~88B) and the Anthropic list-price ratio ($5/$25 vs $3/$15) both imply roughly 1.7-2x, not the 3x used in earlier releases. Honest band: 2x-5x Sonnet (Opus is unmeasured; EcoLogits' absolute Opus number is unstable across model generations).
+- Haiku = 0.5x Sonnet (smaller model, lighter compute). Wide band: Jegham's measured 3.5 Haiku reads higher than Sonnet (a serving/latency artifact), while EcoLogits' modern dense Haiku reads far lower; 0.5x is a physically-plausible middle.
 - Fable = 2x Opus (no published measurement for Fable 5 / Mythos 5; the list-price ratio, $10/$50 vs $5/$25, is used as a compute proxy)
-- Opus = 3x Sonnet (larger model, roughly proportional parameter count)
-- Haiku = 0.5x Sonnet (smaller model, lighter compute)
 
-These are order-of-magnitude estimates. Actual values depend on Anthropic's specific hardware configuration and batching strategies, which are not publicly available.
+These are order-of-magnitude estimates. Actual values depend on Anthropic's specific hardware configuration and batching strategies, which are not publicly available. Only Sonnet is measured; the others carry the uncertainty bands noted above.
 
 ## Excluded models (non-Anthropic)
 
@@ -68,7 +81,7 @@ Claude Code purges JSONL transcripts after about 30 days, so the SQLite DB is th
 
 1. **Capture before purge.** The `Stop` hook (`persist-session.sh`) writes each session to the DB when it ends, while the JSONL still exists. A throttled `SessionStart` hook (`safety-rescan.sh`) re-runs `backfill.sh` once a day in the background to catch any session the `Stop` hook missed (crash, kill, hook disabled), as long as its transcript is still within the 30-day window. The only unavoidable gaps are history older than the install date and downtime longer than 30 days.
 
-2. **Store raw tokens, derive on demand.** Each row stores the raw token breakdown: `input_tokens` (regular input + cache write), `cache_creation_tokens` (cache write), `cache_read_tokens`, and `output_tokens`. Cost and CO2 are pure functions of these counts plus `data/factors.json` and `data/prices.json`, so they can be regenerated at any time with `recompute.sh` without re-reading the (purged) JSONL. When Anthropic changes a price, or a factor is revised, edit the config and run `recompute.sh`. Rows are tagged `methodology_version`; only version >= 2 carries the full raw-token breakdown, so older rows captured before this change are left untouched as legacy.
+2. **Store raw tokens, derive on demand.** Each row stores the raw token breakdown: `input_tokens` (regular input + cache write), `cache_creation_tokens` (cache write), `cache_read_tokens`, and `output_tokens`. Cost and CO2 are pure functions of these counts plus `data/factors.json` and `data/prices.json`, so they can be regenerated at any time with `recompute.sh` without re-reading the (purged) JSONL. When a CO2 factor is revised, run `recompute.sh` (CO2-only by default); when a price changes, run `recompute.sh --with-cost` (cost re-pricing collapses mixed-model rows to the dominant model, ~6% high on subagent sessions, so it is opt-in). Rows are tagged `methodology_version`; only version >= 2 carries the full raw-token breakdown, so older rows captured before this change are left untouched as legacy.
 
 `recompute.sh` recomputes a mixed-model session (subagents on a different model) at the row's dominant model, a small approximation; the original insert is model-accurate per subagent.
 
@@ -84,7 +97,9 @@ Sources: GreenCache (arXiv:2505.23970), TokenPowerBench (arXiv:2512.03024), Solo
 
 ## Cost estimate
 
-The `cost_usd` column is the theoretical API list value of the usage (what it would cost on pay-as-you-go), not the subscription price actually paid. It uses current Anthropic list pricing per million tokens: Opus 4.6+ at $5 input / $25 output (not the retired $15/$75 of Opus 4.0/4.1), Sonnet at $3/$15, Haiku at $1/$5. Cache write is billed at 1.25x input and cache read at 0.1x input. On deduplicated data this reconciles to within a few percent of ccusage.
+The `cost_usd` column is the theoretical API list value of the usage (what it would cost on pay-as-you-go), not the subscription price actually paid. It uses current Anthropic list pricing per million tokens (reconfirmed 2026-06-22): Opus 4.6+ at $5 input / $25 output (not the retired $15/$75 of Opus 4.0/4.1), Sonnet at $3/$15, Haiku at $1/$5, Fable 5 at $10/$50. Cache write is billed at 1.25x input (the 5-minute tier, Claude Code's default; the 1-hour tier is 2x) and cache read at 0.1x input. On deduplicated data this reconciles to within a few percent of ccusage.
+
+For EUR, `data/prices.json` carries `eur_per_usd` (ECB euro reference rate, 0.8729 as of 2026-06-22); convert `cost_usd` at display time rather than storing EUR amounts, so a single dated rate stays the only source of truth and historical rows never need re-conversion. The recent USD/EUR range is tight (~±1%), so a monthly refresh keeps EUR accurate well within the CO2/cost uncertainty.
 
 ## Limitations
 
@@ -92,7 +107,7 @@ The `cost_usd` column is the theoretical API list value of the usage (what it wo
 - Inference only. Training costs, hardware manufacturing, and cooling water are not included.
 - Cache read energy is a derived estimate, not a measurement (see Cache read energy below). Cache reads are 90%+ of tokens in Claude Code, so the chosen factor (default 0.08) is the single biggest lever on the headline number.
 - Status line is approximate. Claude Code does not expose `cache_read_input_tokens` separately in the statusline hook JSON, and parsing JSONL incrementally at each turn would be too slow. The live display uses `context_window.total_input_tokens` (current context size, includes cache reads, no subagents). This is not used in reports.
-- Grid-average, not real-time. The CIF is a static US grid average. Actual emissions depend on Anthropic's datacenter location, energy mix, and time of day.
+- Grid-average, not real-time. The CIF is the static AWS region grid intensity (location-based, 0.287); the US national average is higher (~380 g/kWh). Actual emissions depend on Anthropic's datacenter location, energy mix, and time of day.
 - No multi-region awareness. AWS runs inference in multiple regions with different grid intensities.
 
 ## Equivalences used in reports

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ claude-carbon ⌥ main | 🟢 Opus 4.7 ▓▓▓░░░░░░░ 35% | $0.5
 
 Segments, left to right: project + git branch, model + context window %, session cost + CO2, 5h block usage % + reset time. A 🔥 prefix appears when the sustained burn rate would overshoot 100% of the limit by the end of the 5h block (after a 15 min grace window, only once usage reaches 15%).
 
+> **Terminal and IDE only.** claude-carbon runs through the Claude Code status line and shell hooks, which execute in the terminal CLI and IDE extensions. They do not run in the web app (claude.ai/code) or the desktop app, so no CO2 is displayed or recorded there.
+
 **5h quota source.** The percentage comes directly from Anthropic's `/api/oauth/usage` endpoint (the same data Claude Code displays in `/usage`). No heuristic, no token-limit file to seed. Two sources in order:
 
 1. **stdin** (preferred): if Claude Code injects `rate_limits.five_hour.used_percentage` in the statusline JSON, that value is used straight away.
@@ -33,6 +35,7 @@ Accurate on every plan, including Max 20x.
 
 - `/carbon-report` - text report with totals, equivalences, top sessions
 - `/carbon-card` - generate shareable PNG report cards (requires `playwright-core`, see [Dependencies](#dependencies))
+- `/carbon-update` - update to the latest version and re-price history (see [Updating](#updating))
 
 ## What it does
 
@@ -139,6 +142,7 @@ bash scripts/recompute.sh
 | ---------------- | --------------------------------------------------- |
 | `/carbon-report` | Text report with totals, equivalences, top sessions |
 | `/carbon-card`   | Generate shareable PNG report cards                 |
+| `/carbon-update` | Update to the latest version and re-price history   |
 
 <details>
 <summary>Scripts (run automatically, rarely needed manually)</summary>
@@ -163,17 +167,17 @@ Factors from [Jegham et al. 2025](https://arxiv.org/abs/2505.09598), a peer-revi
 
 | Model  | Input (gCO2e/Mtok) | Output (gCO2e/Mtok) | Basis                      |
 | ------ | ------------------ | ------------------- | -------------------------- |
-| Fable  | 1000               | 6000                | Extrapolated (2x Opus)     |
-| Opus   | 500                | 3000                | Extrapolated (3x Sonnet)   |
-| Sonnet | 190                | 1140                | Measured                   |
-| Haiku  | 95                 | 570                 | Extrapolated (0.5x Sonnet) |
+| Fable  | 156                | 3304                | Extrapolated (2x Opus)     |
+| Opus   | 78                 | 1652                | Extrapolated (2x Sonnet)   |
+| Sonnet | 39                 | 826                 | 3-point fit (Jegham v6)    |
+| Haiku  | 20                 | 413                 | Extrapolated (0.5x Sonnet) |
 
 **Important: these are order-of-magnitude estimates, not precise measurements.**
 
-- Sonnet factors are derived from Jegham et al. direct measurements. Fable, Opus and Haiku are extrapolated (no public data from Anthropic on per-model energy consumption).
+- Sonnet factors are a 3-point least-squares fit to the three measured Claude 3.7 Sonnet per-query energies in Jegham et al. v6 (0.950 / 2.989 / 5.671 Wh), giving a ~21:1 output:input ratio. The value is cross-validated against [EcoLogits](https://ecologits.ai): its independent estimate for Sonnet brackets the same range. Fable, Opus and Haiku are extrapolated (no public data from Anthropic on per-model energy consumption); Opus = 2x Sonnet matches both the current EcoLogits Opus 4.5+ parameter ratio and the Anthropic price ratio (honest band 2x-5x).
 - Sessions run on non-Anthropic models (e.g. local models behind `ANTHROPIC_BASE_URL`) are stored with their raw tokens but zero cost/CO2 and excluded from reports - a datacenter factor doesn't apply to them. Add patterns to `exclude_models` in `data/factors.json` to exclude more models by name.
 - Cache read tokens are counted at a reduced factor (default 0.08 of an input token, set in `data/factors.json`). A cached token skips prefill compute but still incurs decode-phase memory reads, so it is cheap but not free. This is an engineering estimate derived from the literature, not Anthropic's 0.1x billing ratio. See [METHODOLOGY.md](METHODOLOGY.md).
-- Carbon intensity uses AWS grid-average (0.287 kgCO2e/kWh), not real-time grid data.
+- Carbon intensity uses the AWS region grid (location-based, 0.287 kgCO2e/kWh), not real-time grid data. This sits at the low end of the location-based range; the US national average is ~380 g/kWh.
 - Anthropic does not publish Scope 1, 2, or 3 emissions. These estimates are independent and based on academic research, not provider data.
 
 Factors are editable in `data/factors.json`. See [METHODOLOGY.md](METHODOLOGY.md) for the full scientific basis, formula, and equivalences.
@@ -181,6 +185,20 @@ Factors are editable in `data/factors.json`. See [METHODOLOGY.md](METHODOLOGY.md
 ### Golden vectors
 
 The methodology is pinned by golden test vectors in [`tests/methodology-vectors.json`](tests/methodology-vectors.json): hand-computed expected CO2/cost values for known token breakdowns, replayed by `bash tests/run-vectors.sh` in CI on every push. Downstream consumers (such as TokenClimate) keep a copy of this file and verify weekly that their implementation produces the same numbers. If you edit `data/factors.json` or `data/prices.json`, update the vectors in the same commit, otherwise CI fails.
+
+## Updating
+
+When a newer version is available, the status line shows a discreet `⬆ /carbon-update` hint. The check runs in the background (at most once a day, never on the status line's hot path); opt out with `CLAUDE_CARBON_NO_UPDATE_NOTIFIER=1`.
+
+To update, run `/carbon-update` in Claude Code, or re-run the installer:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/gwittebolle/claude-carbon/main/install.sh | bash
+```
+
+- Updating re-prices your stored history with the new factors automatically (CO2 only; cost figures are left intact). Run `scripts/recompute.sh --with-cost` yourself only after a price change.
+- If you edited `data/factors.json` or `data/prices.json` locally, the update keeps your edits; on a conflict with upstream it saves yours to `*.local.bak` and tells you.
+- Installed via the plugin marketplace? Update with Claude Code's built-in `/plugin update` instead.
 
 ## Dependencies
 
@@ -205,7 +223,7 @@ Measuring is step one. Here are concrete levers to reduce your AI carbon footpri
 
 ### Use the right model for the task
 
-Output tokens cost 5x more energy than input tokens. Opus consumes ~3x more than Sonnet per token.
+Output tokens cost ~21x more energy than input tokens (the marginal output:input ratio from Jegham v6). Opus consumes ~2x more than Sonnet per token.
 
 ```json
 {

--- a/data/factors.json
+++ b/data/factors.json
@@ -1,15 +1,15 @@
 {
-  "_methodology": "Jegham et al. 2025 - AWS PUE 1.14, CIF 0.287 kgCO2e/kWh",
+  "_methodology": "Jegham et al. 2025 (v6) - AWS PUE 1.14, AWS region grid CIF 0.287 kgCO2e/kWh (location-based; US average is ~380). Sonnet input/output are a 3-point OLS fit to the three measured Claude 3.7 Sonnet per-query energies (0.950 / 2.989 / 5.671 Wh); marginal ratio ~21:1 output:input. Cross-validated against EcoLogits (GenAI Impact), bracketing the same range. Opus = 2x Sonnet (EcoLogits Opus 4.5+ params and the Anthropic price ratio both imply ~1.7-2x; band 2x-5x), Haiku = 0.5x, Fable = 2x Opus. Order-of-magnitude estimates.",
   "_units": "gCO2e per million tokens",
   "_source": "https://arxiv.org/abs/2505.09598",
   "_cache_read_factor": "Energy of a cache_read token as a fraction of an uncached input token. Engineering estimate (~0.08, defensible range 0.05-0.15) derived from the decode-phase KV re-read residual. NOT Anthropic's 0.1x billing ratio (a price, not energy). See METHODOLOGY.md.",
   "cache_read_factor": 0.08,
   "_fable": "No published measurement for Fable 5 (claude-fable-5 / claude-mythos-5). Extrapolated from Opus by the list-price ratio (2x, $10/$50 vs $5/$25), same approach as the Opus 3x-Sonnet extrapolation.",
   "models": {
-    "fable": { "input": 1000, "output": 6000 },
-    "opus": { "input": 500, "output": 3000 },
-    "sonnet": { "input": 190, "output": 1140 },
-    "haiku": { "input": 95, "output": 570 }
+    "fable": { "input": 156, "output": 3304 },
+    "opus": { "input": 78, "output": 1652 },
+    "sonnet": { "input": 39, "output": 826 },
+    "haiku": { "input": 20, "output": 413 }
   },
   "_exclude_models": "Sessions whose model string does not contain 'claude' (e.g. local models served behind ANTHROPIC_BASE_URL) are always stored with cost_usd=0, co2_grams=0 and excluded=1, and left out of report aggregates. Add case-insensitive grep -E patterns here to exclude additional models by name.",
   "exclude_models": []

--- a/data/prices.json
+++ b/data/prices.json
@@ -1,7 +1,7 @@
 {
   "_units": "USD per million tokens — current Anthropic list price (pay-as-you-go API value).",
-  "_note": "Fable 5 (claude-fable-5 / claude-mythos-5) is 10/50. Opus 4.6+ is 5/25 (the retired 4.0/4.1 was 15/75). cache_write = input x cache_write_multiplier (5-min TTL), cache_read = input x cache_read_multiplier. After editing, run scripts/recompute.sh to re-derive cost_usd for all raw-token rows without needing the (purged) JSONL.",
-  "_updated": "2026-06-12",
+  "_note": "Fable 5 (claude-fable-5 / claude-mythos-5) is 10/50. Opus 4.6+ is 5/25 (the retired 4.0/4.1 was 15/75). cache_write = input x cache_write_multiplier (5-min TTL), cache_read = input x cache_read_multiplier. After editing prices, run `scripts/recompute.sh --with-cost` to re-derive cost_usd for all raw-token rows (plain `recompute.sh` re-derives CO2 only), without needing the (purged) JSONL.",
+  "_updated": "2026-06-22",
   "models": {
     "fable": { "input": 10, "output": 50 },
     "opus": { "input": 5, "output": 25 },
@@ -9,5 +9,7 @@
     "haiku": { "input": 1, "output": 5 }
   },
   "cache_write_multiplier": 1.25,
-  "cache_read_multiplier": 0.1
+  "cache_read_multiplier": 0.1,
+  "eur_per_usd": 0.8729,
+  "_eur_per_usd_note": "ECB euro reference rate 2026-06-22 (1 EUR = 1.1456 USD). Convert USD costs to EUR at display time; do not store EUR amounts. Refresh ~monthly from ECB. cache_write_multiplier 1.25 is the 5-min tier (Claude Code default); the 1-hour cache-write tier is 2x input."
 }

--- a/install.sh
+++ b/install.sh
@@ -25,10 +25,32 @@ for cmd in jq sqlite3 git; do
   fi
 done
 
-# 2. Clone or update
+# 2. Clone (fresh) or update (existing, dirty-safe against locally-edited data files)
+WAS_UPDATE=0
 if [ -d "$INSTALL_DIR/.git" ]; then
   echo "Updating existing installation at $INSTALL_DIR..."
-  git -C "$INSTALL_DIR" pull --ff-only --quiet
+  WAS_UPDATE=1
+  export GIT_TERMINAL_PROMPT=0 GIT_HTTP_LOW_SPEED_LIMIT=1000 GIT_HTTP_LOW_SPEED_TIME=20
+  # The README invites editing data/factors.json, which breaks `git pull --ff-only`.
+  # Stash just those two tracked files, pull, restore; on conflict keep upstream + back up theirs.
+  STASHED=0
+  if [ -n "$(git -C "$INSTALL_DIR" status --porcelain -- data/factors.json data/prices.json 2>/dev/null || true)" ]; then
+    if git -C "$INSTALL_DIR" stash push --quiet -m "claude-carbon-install" -- data/factors.json data/prices.json 2>/dev/null; then
+      STASHED=1
+    fi
+  fi
+  git -C "$INSTALL_DIR" pull --ff-only --quiet \
+    || echo "  WARNING: could not fast-forward. Resolve with: cd $INSTALL_DIR && git status"
+  if [ "$STASHED" = "1" ]; then
+    if ! git -C "$INSTALL_DIR" stash pop --quiet 2>/dev/null; then
+      for f in data/factors.json data/prices.json; do
+        git -C "$INSTALL_DIR" show "stash@{0}:$f" > "${INSTALL_DIR}/${f}.local.bak" 2>/dev/null || true
+      done
+      git -C "$INSTALL_DIR" checkout --quiet HEAD -- data/factors.json data/prices.json 2>/dev/null || true
+      git -C "$INSTALL_DIR" stash drop --quiet 2>/dev/null || true
+      echo "  Your local factors/prices edits were saved to *.local.bak (re-apply manually)."
+    fi
+  fi
 else
   echo "Cloning to $INSTALL_DIR..."
   mkdir -p "$(dirname "$INSTALL_DIR")"
@@ -38,6 +60,14 @@ fi
 # 3. Run setup (creates DB, backfills history)
 echo ""
 CLAUDE_CARBON_INSTALLER=1 bash "$INSTALL_DIR/scripts/setup.sh"
+
+# 3b. On update, re-price stored history with the new factors (CO2-only; cost left intact).
+if [ "$WAS_UPDATE" = "1" ]; then
+  DB_PATH="${CLAUDE_CARBON_DB:-${HOME}/.claude/claude-carbon/carbon.db}"
+  if [ -f "$DB_PATH" ]; then
+    bash "$INSTALL_DIR/scripts/recompute.sh" || echo "  (history not re-priced; see message above)"
+  fi
+fi
 
 # 4. Configure Claude Code settings
 echo ""
@@ -109,7 +139,7 @@ SKILL_SOURCE="${INSTALL_DIR}/skills/carbon-report/SKILL.md"
 SKILL_LINK="${COMMANDS_DIR}/carbon-report.md"
 
 mkdir -p "$COMMANDS_DIR"
-for SKILL_NAME in carbon-report carbon-card; do
+for SKILL_NAME in carbon-report carbon-card carbon-update; do
   SKILL_SRC="${INSTALL_DIR}/skills/${SKILL_NAME}/SKILL.md"
   SKILL_LNK="${COMMANDS_DIR}/${SKILL_NAME}.md"
   if [ -L "$SKILL_LNK" ] || [ -f "$SKILL_LNK" ]; then

--- a/scripts/backfill.sh
+++ b/scripts/backfill.sh
@@ -24,8 +24,8 @@ sqlite3 "$DB_PATH" "ALTER TABLE sessions ADD COLUMN methodology_version INTEGER 
 sqlite3 "$DB_PATH" "ALTER TABLE sessions ADD COLUMN excluded INTEGER DEFAULT 0;" 2>/dev/null || true
 
 # Load emission factors once (gCO2e per million tokens)
-FACTOR_FABLE_IN="$(jq -r '.models.fable.input // 1000' "$FACTORS_FILE")"
-FACTOR_FABLE_OUT="$(jq -r '.models.fable.output // 6000' "$FACTORS_FILE")"
+FACTOR_FABLE_IN="$(jq -r '.models.fable.input // 156' "$FACTORS_FILE")"
+FACTOR_FABLE_OUT="$(jq -r '.models.fable.output // 3304' "$FACTORS_FILE")"
 FACTOR_OPUS_IN="$(jq -r '.models.opus.input' "$FACTORS_FILE")"
 FACTOR_OPUS_OUT="$(jq -r '.models.opus.output' "$FACTORS_FILE")"
 FACTOR_SONNET_IN="$(jq -r '.models.sonnet.input' "$FACTORS_FILE")"

--- a/scripts/check-update.sh
+++ b/scripts/check-update.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# check-update.sh — backgrounded, throttled remote version check. Writes a cached flag
+# (~/.claude/claude-carbon/update-check.json) that statusline.sh reads locally. NEVER run
+# this from the statusline: it does network I/O. It is launched detached by the SessionStart
+# hook (safety-rescan.sh), at most once/day. Swallows every error; safe to kill anytime.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(dirname "$SCRIPT_DIR")"
+STATE_DIR="${HOME}/.claude/claude-carbon"
+OUT="${STATE_DIR}/update-check.json"
+
+# Opt-out (mirrors npm/gh NO_UPDATE_NOTIFIER convention)
+[ -n "${CLAUDE_CARBON_NO_UPDATE_NOTIFIER:-}" ] && exit 0
+
+# Only a real git-clone install, and NOT Claude Code's managed marketplace cache clone
+# (marketplace users get native auto-update; we must never mutate or false-nag that clone).
+[ -d "${REPO_DIR}/.git" ] || exit 0
+case "$REPO_DIR" in */.claude/plugins/*) exit 0 ;; esac
+command -v jq  >/dev/null 2>&1 || exit 0
+command -v git >/dev/null 2>&1 || exit 0
+# Version-sort is required to compare semver; ancient BusyBox lacks `sort -V` and would
+# mis-rank (e.g. 1.10.0 < 1.9.0). Bail rather than emit a wrong notice.
+printf '1.0\n1.0.1\n' | sort -V >/dev/null 2>&1 || exit 0
+mkdir -p "$STATE_DIR" 2>/dev/null || exit 0
+
+LOCAL_V="$(jq -r '.version // empty' "${REPO_DIR}/.claude-plugin/plugin.json" 2>/dev/null)"
+[ -n "$LOCAL_V" ] || exit 0
+
+# Native git timeouts (portable, work even where coreutils `timeout` is absent, e.g. stock macOS).
+export GIT_TERMINAL_PROMPT=0 GIT_HTTP_LOW_SPEED_LIMIT=1000 GIT_HTTP_LOW_SPEED_TIME=20
+# Belt-and-suspenders hard timeout if available (gtimeout on macOS via coreutils).
+TO=""
+if command -v timeout  >/dev/null 2>&1; then TO="timeout 25"
+elif command -v gtimeout >/dev/null 2>&1; then TO="gtimeout 25"; fi
+
+# Detect origin's default branch; fall back to main.
+DEF_BRANCH="$(git -C "$REPO_DIR" symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's#^origin/##')"
+[ -n "$DEF_BRANCH" ] || DEF_BRANCH=main
+
+# Fetch the ref only (no checkout, no merge, no working-tree change).
+$TO git -C "$REPO_DIR" fetch --quiet origin "$DEF_BRANCH" 2>/dev/null || exit 0
+
+# Compare versions (a string field), not raw HEAD SHA — so docs/CI commits never nag.
+REMOTE_V="$(git -C "$REPO_DIR" show "origin/${DEF_BRANCH}:.claude-plugin/plugin.json" 2>/dev/null \
+            | jq -r '.version // empty' 2>/dev/null)"
+[ -n "$REMOTE_V" ] || exit 0
+
+# behind = remote is strictly newer (semver via sort -V).
+BEHIND=false
+if [ "$LOCAL_V" != "$REMOTE_V" ] && \
+   [ "$(printf '%s\n%s\n' "$LOCAL_V" "$REMOTE_V" | sort -V | tail -1)" = "$REMOTE_V" ]; then
+  BEHIND=true
+fi
+
+# Atomic write (tmp + mv) so the per-turn statusline never reads a torn file.
+TMP="${OUT}.tmp.$$"
+printf '{"behind":%s,"local":"%s","remote":"%s","checked_at":%s}\n' \
+  "$BEHIND" "$LOCAL_V" "$REMOTE_V" "$(date +%s)" > "$TMP" 2>/dev/null && mv -f "$TMP" "$OUT"
+exit 0

--- a/scripts/persist-session.sh
+++ b/scripts/persist-session.sh
@@ -24,8 +24,8 @@ sqlite3 "$DB_PATH" "ALTER TABLE sessions ADD COLUMN methodology_version INTEGER 
 sqlite3 "$DB_PATH" "ALTER TABLE sessions ADD COLUMN excluded INTEGER DEFAULT 0;" 2>/dev/null || true
 
 # Load emission factors once
-FACTOR_FABLE_IN="$(jq -r '.models.fable.input // 1000' "$FACTORS_FILE" 2>/dev/null)" || FACTOR_FABLE_IN="1000"
-FACTOR_FABLE_OUT="$(jq -r '.models.fable.output // 6000' "$FACTORS_FILE" 2>/dev/null)" || FACTOR_FABLE_OUT="6000"
+FACTOR_FABLE_IN="$(jq -r '.models.fable.input // 156' "$FACTORS_FILE" 2>/dev/null)" || FACTOR_FABLE_IN="156"
+FACTOR_FABLE_OUT="$(jq -r '.models.fable.output // 3304' "$FACTORS_FILE" 2>/dev/null)" || FACTOR_FABLE_OUT="3304"
 FACTOR_OPUS_IN="$(jq -r '.models.opus.input' "$FACTORS_FILE" 2>/dev/null)" || exit 0
 FACTOR_OPUS_OUT="$(jq -r '.models.opus.output' "$FACTORS_FILE" 2>/dev/null)" || exit 0
 FACTOR_SONNET_IN="$(jq -r '.models.sonnet.input' "$FACTORS_FILE" 2>/dev/null)" || exit 0

--- a/scripts/recompute.sh
+++ b/scripts/recompute.sh
@@ -3,7 +3,10 @@ set -euo pipefail
 
 # recompute.sh — Re-derive cost_usd and co2_grams for stored sessions from their raw token
 # counts and the CURRENT data/factors.json + data/prices.json, without reading any JSONL.
-# Run this after changing pricing, CO2 factors, or the cache_read_factor.
+# Run this after changing CO2 factors or the cache_read_factor. By DEFAULT it recomputes
+# co2_grams ONLY (safe and idempotent). Pass --with-cost (alias --prices) to ALSO re-derive
+# cost_usd — only do that after editing prices.json, because cost re-pricing collapses
+# mixed-model (subagent) sessions to the row's dominant model, inflating their cost by ~6%.
 #
 # This is the answer to Anthropic's 30-day transcript purge: the raw token breakdown is
 # captured once (by the Stop hook, within the 30-day window) and frozen; everything derived
@@ -21,8 +24,12 @@ DB_PATH="${CLAUDE_CARBON_DB:-${HOME}/.claude/claude-carbon/carbon.db}"
 
 [ -f "$DB_PATH" ] || { echo "No database at ${DB_PATH}" >&2; exit 1; }
 
+# Default: CO2 only. --with-cost / --prices also re-derives cost_usd (see header caveat).
+WITH_COST=0
+case "${1:-}" in --with-cost|--prices) WITH_COST=1 ;; esac
+
 # Emission factors (gCO2e per million tokens) + cache_read energy fraction
-F_FAB_IN="$(jq -r '.models.fable.input // 1000' "$FACTORS_FILE")"; F_FAB_OUT="$(jq -r '.models.fable.output // 6000' "$FACTORS_FILE")"
+F_FAB_IN="$(jq -r '.models.fable.input // 156' "$FACTORS_FILE")"; F_FAB_OUT="$(jq -r '.models.fable.output // 3304' "$FACTORS_FILE")"
 F_OPUS_IN="$(jq -r '.models.opus.input' "$FACTORS_FILE")";    F_OPUS_OUT="$(jq -r '.models.opus.output' "$FACTORS_FILE")"
 F_SON_IN="$(jq -r '.models.sonnet.input' "$FACTORS_FILE")";   F_SON_OUT="$(jq -r '.models.sonnet.output' "$FACTORS_FILE")"
 F_HAI_IN="$(jq -r '.models.haiku.input' "$FACTORS_FILE")";    F_HAI_OUT="$(jq -r '.models.haiku.output' "$FACTORS_FILE")"
@@ -36,6 +43,20 @@ P_HAI_IN="$(jq -r '.models.haiku.input' "$PRICES_FILE")";     P_HAI_OUT="$(jq -r
 CW_MULT="$(jq -r '.cache_write_multiplier // 1.25' "$PRICES_FILE")"
 CR_MULT="$(jq -r '.cache_read_multiplier // 0.1' "$PRICES_FILE")"
 
+# These values are interpolated directly into the UPDATE SQL below, and the installers auto-run
+# this script against freshly-pulled data files. Refuse anything that isn't a plain number so a
+# malformed or hostile factors.json/prices.json can never inject SQL.
+for _v in "$F_FAB_IN" "$F_FAB_OUT" "$F_OPUS_IN" "$F_OPUS_OUT" "$F_SON_IN" "$F_SON_OUT" \
+          "$F_HAI_IN" "$F_HAI_OUT" "$CRF" \
+          "$P_FAB_IN" "$P_FAB_OUT" "$P_OPUS_IN" "$P_OPUS_OUT" "$P_SON_IN" "$P_SON_OUT" \
+          "$P_HAI_IN" "$P_HAI_OUT" "$CW_MULT" "$CR_MULT"; do
+  case "$_v" in
+    ''|*[!0-9.eE+-]*)
+      echo "recompute: non-numeric value in factors/prices ('${_v}'); refusing to run." >&2
+      exit 1 ;;
+  esac
+done
+
 # co2  = (input_tokens * fin + cache_read_tokens * (fin*CRF) + output_tokens * fout) / 1e6
 #        (input_tokens already = regular_input + cache_write, both at the input factor)
 # cost = ((input_tokens - cache_creation_tokens) * pin              -- regular input
@@ -44,12 +65,20 @@ CR_MULT="$(jq -r '.cache_read_multiplier // 0.1' "$PRICES_FILE")"
 #         + output_tokens * pout) / 1e6
 update_family() {
   local where="$1" fin="$2" fout="$3" pin="$4" pout="$5"
-  sqlite3 "$DB_PATH" "
-    UPDATE sessions SET
-      co2_grams = (input_tokens*${fin} + cache_read_tokens*(${fin}*${CRF}) + output_tokens*${fout}) / 1000000.0,
-      cost_usd  = ((input_tokens - cache_creation_tokens)*${pin} + cache_creation_tokens*(${pin}*${CW_MULT}) + cache_read_tokens*(${pin}*${CR_MULT}) + output_tokens*${pout}) / 1000000.0
-    WHERE methodology_version >= 2 AND COALESCE(excluded, 0) = 0 AND ${where};
-  "
+  if [ "$WITH_COST" = "1" ]; then
+    sqlite3 -cmd ".timeout 5000" "$DB_PATH" "
+      UPDATE sessions SET
+        co2_grams = (input_tokens*${fin} + cache_read_tokens*(${fin}*${CRF}) + output_tokens*${fout}) / 1000000.0,
+        cost_usd  = ((input_tokens - cache_creation_tokens)*${pin} + cache_creation_tokens*(${pin}*${CW_MULT}) + cache_read_tokens*(${pin}*${CR_MULT}) + output_tokens*${pout}) / 1000000.0
+      WHERE methodology_version >= 2 AND COALESCE(excluded, 0) = 0 AND ${where};
+    "
+  else
+    sqlite3 -cmd ".timeout 5000" "$DB_PATH" "
+      UPDATE sessions SET
+        co2_grams = (input_tokens*${fin} + cache_read_tokens*(${fin}*${CRF}) + output_tokens*${fout}) / 1000000.0
+      WHERE methodology_version >= 2 AND COALESCE(excluded, 0) = 0 AND ${where};
+    "
+  fi
 }
 
 update_family "(model LIKE '%fable%' OR model LIKE '%mythos%')" "$F_FAB_IN" "$F_FAB_OUT" "$P_FAB_IN" "$P_FAB_OUT"
@@ -62,5 +91,10 @@ LEGACY="$(sqlite3 "$DB_PATH" "SELECT COUNT(*) FROM sessions WHERE methodology_ve
 TOTAL_COST="$(sqlite3 "$DB_PATH" "SELECT printf('%.0f', COALESCE(SUM(cost_usd),0)) FROM sessions;")"
 TOTAL_CO2_KG="$(sqlite3 "$DB_PATH" "SELECT printf('%.0f', COALESCE(SUM(co2_grams),0)/1000.0) FROM sessions;")"
 
-echo "Recomputed ${RECOMPUTED} rows from raw tokens (left ${LEGACY} legacy rows untouched)."
+if [ "$WITH_COST" = "1" ]; then
+  echo "Re-priced cost at the dominant model for mixed-model rows (~6% high on subagent sessions)."
+  echo "Recomputed CO2 + cost for ${RECOMPUTED} rows (left ${LEGACY} legacy rows untouched)."
+else
+  echo "Recomputed CO2 for ${RECOMPUTED} rows (cost unchanged; left ${LEGACY} legacy rows untouched)."
+fi
 echo "DB totals now: \$${TOTAL_COST} / ${TOTAL_CO2_KG} kg CO2."

--- a/scripts/safety-rescan.sh
+++ b/scripts/safety-rescan.sh
@@ -10,11 +10,37 @@ DB_DIR="${HOME}/.claude/claude-carbon"
 DB_PATH="${CLAUDE_CARBON_DB:-${DB_DIR}/carbon.db}"
 STAMP="${DB_DIR}/.last-rescan"
 
+# Portable detach: fully background a command so it survives session-start exit. setsid is
+# absent on macOS, so probe it. (The old `( setsid … & ) || ( … & )` idiom never reached its
+# fallback, because backgrounding always makes the subshell exit 0 — so on macOS nothing ran.)
+detach() {
+  if command -v setsid >/dev/null 2>&1; then
+    setsid "$@" >/dev/null 2>&1 </dev/null &
+  elif command -v nohup >/dev/null 2>&1; then
+    nohup "$@" >/dev/null 2>&1 </dev/null &
+  else
+    "$@" >/dev/null 2>&1 </dev/null &
+  fi
+}
+
 # Drain stdin so the hook never blocks on an unread pipe
 cat >/dev/null 2>&1 || true
 
 # Only if the plugin is set up
 [ -f "$DB_PATH" ] || exit 0
+
+# Daily "update available" check, fully detached. Its own throttle (keyed on the flag file's
+# own age) so a failed/offline run self-heals next SessionStart, and it runs even on days the
+# backfill below is throttled. The statusline only ever reads the flag this writes.
+UPD_FILE="${DB_DIR}/update-check.json"
+NEED_CHECK=1
+if [ -f "$UPD_FILE" ] && command -v jq >/dev/null 2>&1; then
+  CA="$(jq -r '.checked_at // 0' "$UPD_FILE" 2>/dev/null || echo 0)"
+  [ "$(( $(date +%s) - CA ))" -lt 86400 ] 2>/dev/null && NEED_CHECK=0
+fi
+if [ "$NEED_CHECK" = "1" ]; then
+  detach bash "${SCRIPT_DIR}/check-update.sh"
+fi
 
 # Throttle: skip if a rescan ran in the last 24h
 if [ -f "$STAMP" ]; then
@@ -25,7 +51,6 @@ fi
 
 # Mark now, then run backfill fully detached so session start is never delayed
 touch "$STAMP" 2>/dev/null || true
-( setsid bash "${SCRIPT_DIR}/backfill.sh" >/dev/null 2>&1 < /dev/null & ) >/dev/null 2>&1 || \
-  ( bash "${SCRIPT_DIR}/backfill.sh" >/dev/null 2>&1 < /dev/null & ) >/dev/null 2>&1
+detach bash "${SCRIPT_DIR}/backfill.sh"
 
 exit 0

--- a/scripts/statusline.sh
+++ b/scripts/statusline.sh
@@ -35,8 +35,8 @@ fi
 # Load emission factors (zero for non-Anthropic models, e.g. local models
 # behind ANTHROPIC_BASE_URL — a datacenter factor doesn't apply to them)
 if echo "$MODEL_ID" | grep -qi "claude"; then
-  FACTOR_IN="$(jq -r ".models.${MODEL_FAMILY}.input // 190" "$FACTORS_FILE")"
-  FACTOR_OUT="$(jq -r ".models.${MODEL_FAMILY}.output // 1140" "$FACTORS_FILE")"
+  FACTOR_IN="$(jq -r ".models.${MODEL_FAMILY}.input // 39" "$FACTORS_FILE")"
+  FACTOR_OUT="$(jq -r ".models.${MODEL_FAMILY}.output // 826" "$FACTORS_FILE")"
 else
   FACTOR_IN="0"
   FACTOR_OUT="0"
@@ -185,4 +185,18 @@ if [ -n "$CURRENT_DIR" ] && command -v git &>/dev/null; then
   [ -n "$BRANCH" ] && [ "$BRANCH" != "HEAD" ] && BRANCH_SUFFIX=" ⌥ ${BRANCH}"
 fi
 
-echo "${PROJECT}${BRANCH_SUFFIX} | ${DOT} ${DISPLAY_NAME} ${PROGRESS_BAR} ${PCT_DISPLAY} | \$${COST_DISPLAY} · ${CO2_DISPLAY}${USAGE_SEGMENT}"
+# "Update available" notice — read-only, network-free. The remote check runs in the background
+# (SessionStart hook → check-update.sh) and writes a cached flag; here we only read it. A 7-day
+# staleness gate means an abandoned flag (background check stopped) self-clears.
+UPDATE_SEGMENT=""
+UPD_FILE="${HOME}/.claude/claude-carbon/update-check.json"
+if [ -z "${CLAUDE_CARBON_NO_UPDATE_NOTIFIER:-}" ] && [ -f "$UPD_FILE" ] && command -v jq &>/dev/null; then
+  if [ "$(jq -r '.behind // false' "$UPD_FILE" 2>/dev/null)" = "true" ]; then
+    UPD_AT="$(jq -r '.checked_at // 0' "$UPD_FILE" 2>/dev/null || echo 0)"
+    if [ "$UPD_AT" -gt 0 ] 2>/dev/null && [ "$(( $(date +%s) - UPD_AT ))" -lt 604800 ] 2>/dev/null; then
+      UPDATE_SEGMENT=" | ⬆ /carbon-update"
+    fi
+  fi
+fi
+
+echo "${PROJECT}${BRANCH_SUFFIX} | ${DOT} ${DISPLAY_NAME} ${PROGRESS_BAR} ${PCT_DISPLAY} | \$${COST_DISPLAY} · ${CO2_DISPLAY}${USAGE_SEGMENT}${UPDATE_SEGMENT}"

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# update.sh — dirty-safe self-update for git-clone installs of claude-carbon.
+# Survives a working tree where the user edited data/factors.json or data/prices.json (the
+# README invites it), which would otherwise break `git pull --ff-only`. Re-runs setup and a
+# CO2-only recompute, then clears the "update available" notice. NOT for marketplace installs.
+set -uo pipefail   # NOT -e: each git step is handled explicitly
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(dirname "$SCRIPT_DIR")"
+STATE_DIR="${HOME}/.claude/claude-carbon"
+
+[ -d "${REPO_DIR}/.git" ] || { echo "Not a git-clone install; nothing to update." >&2; exit 0; }
+case "$REPO_DIR" in
+  */.claude/plugins/*)
+    echo "Installed via the Claude Code plugin marketplace."
+    echo "Update with Claude Code's built-in:  /plugin update claude-carbon"
+    exit 0 ;;
+esac
+command -v git >/dev/null 2>&1 || { echo "git not found." >&2; exit 1; }
+export GIT_TERMINAL_PROMPT=0 GIT_HTTP_LOW_SPEED_LIMIT=1000 GIT_HTTP_LOW_SPEED_TIME=20
+
+# Stash ONLY the two user-editable tracked files (never -u: leaves untracked notes/images alone).
+STASHED=0
+if [ -n "$(git -C "$REPO_DIR" status --porcelain -- data/factors.json data/prices.json 2>/dev/null || true)" ]; then
+  if git -C "$REPO_DIR" stash push --quiet -m "claude-carbon-update" -- data/factors.json data/prices.json 2>/dev/null; then
+    STASHED=1
+  fi
+fi
+
+# Fast-forward pull.
+if git -C "$REPO_DIR" pull --ff-only --quiet 2>/dev/null; then
+  PULL_OK=1
+else
+  PULL_OK=0
+fi
+
+# Restore the user's edits; on conflict, preserve them to *.local.bak and keep upstream clean.
+if [ "$STASHED" = "1" ]; then
+  if ! git -C "$REPO_DIR" stash pop --quiet 2>/dev/null; then
+    for f in data/factors.json data/prices.json; do
+      git -C "$REPO_DIR" show "stash@{0}:$f" > "${REPO_DIR}/${f}.local.bak" 2>/dev/null || true
+    done
+    git -C "$REPO_DIR" checkout --quiet HEAD -- data/factors.json data/prices.json 2>/dev/null || true
+    git -C "$REPO_DIR" stash drop --quiet 2>/dev/null || true
+    echo "Your local factors/prices edits conflicted with the update."
+    echo "They were saved to data/factors.json.local.bak / data/prices.json.local.bak — re-apply manually."
+  fi
+fi
+
+if [ "$PULL_OK" != "1" ]; then
+  echo "Update could not fast-forward (diverged history or network)." >&2
+  echo "Resolve manually:  cd \"${REPO_DIR}\" && git status" >&2
+  exit 1
+fi
+
+# Refresh symlinks/settings, then re-price history (CO2-only by default: cheap, idempotent,
+# no mixed-model cost drift).
+CLAUDE_CARBON_INSTALLER=1 bash "${SCRIPT_DIR}/setup.sh" >/dev/null 2>&1 || true
+DB_PATH="${CLAUDE_CARBON_DB:-${STATE_DIR}/carbon.db}"
+if [ -f "$DB_PATH" ]; then
+  bash "${SCRIPT_DIR}/recompute.sh" || echo "history not re-priced; see message above."
+fi
+
+# Clear the notice immediately so the statusline self-heals before the next daily check.
+NEW_V="$(jq -r '.version // empty' "${REPO_DIR}/.claude-plugin/plugin.json" 2>/dev/null || echo "")"
+if command -v jq >/dev/null 2>&1 && [ -n "$NEW_V" ]; then
+  mkdir -p "$STATE_DIR" 2>/dev/null || true
+  TMP="${STATE_DIR}/update-check.json.tmp.$$"
+  printf '{"behind":false,"local":"%s","remote":"%s","checked_at":%s}\n' \
+    "$NEW_V" "$NEW_V" "$(date +%s)" > "$TMP" 2>/dev/null && mv -f "$TMP" "${STATE_DIR}/update-check.json"
+fi
+
+echo "claude-carbon updated to ${NEW_V:-latest}."

--- a/skills/carbon-update/SKILL.md
+++ b/skills/carbon-update/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: carbon-update
+description: Update claude-carbon to the latest version and re-price history (CO2-only)
+---
+
+Run the following bash script exactly as written and present its output to the user. Do not paraphrase. It updates the user's claude-carbon install (dirty-safe `git pull`), refreshes setup, and re-prices stored sessions with the new factors.
+
+```bash
+#!/usr/bin/env bash
+# Locate the install that is actually wired into the status line, then run its updater.
+REPO_DIR=""
+SETTINGS="${HOME}/.claude/settings.json"
+if command -v jq >/dev/null 2>&1 && [ -f "$SETTINGS" ]; then
+  SL_CMD="$(jq -r '.statusLine.command // empty' "$SETTINGS" 2>/dev/null)"
+  if [ -n "$SL_CMD" ] && [ -f "$SL_CMD" ]; then
+    REPO_DIR="$(cd "$(dirname "$SL_CMD")/.." 2>/dev/null && pwd)"
+  fi
+fi
+[ -z "$REPO_DIR" ] && [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && REPO_DIR="$CLAUDE_PLUGIN_ROOT"
+[ -z "$REPO_DIR" ] && REPO_DIR="${CLAUDE_CARBON_DIR:-$HOME/code/claude-carbon}"
+
+if [ -f "${REPO_DIR}/scripts/update.sh" ]; then
+  bash "${REPO_DIR}/scripts/update.sh"
+else
+  echo "claude-carbon updater not found at ${REPO_DIR}/scripts/update.sh"
+  echo "Re-run the installer to update:"
+  echo "  curl -fsSL https://raw.githubusercontent.com/gwittebolle/claude-carbon/main/install.sh | bash"
+fi
+```

--- a/tests/methodology-vectors.json
+++ b/tests/methodology-vectors.json
@@ -10,10 +10,10 @@
     "cache_write_multiplier": 1.25,
     "cache_read_multiplier": 0.1,
     "factors_gco2e_per_mtok": {
-      "fable": { "input": 1000, "output": 6000 },
-      "opus": { "input": 500, "output": 3000 },
-      "sonnet": { "input": 190, "output": 1140 },
-      "haiku": { "input": 95, "output": 570 }
+      "fable": { "input": 156, "output": 3304 },
+      "opus": { "input": 78, "output": 1652 },
+      "sonnet": { "input": 39, "output": 826 },
+      "haiku": { "input": 20, "output": 413 }
     },
     "prices_usd_per_mtok": {
       "fable": { "input": 10, "output": 50 },
@@ -33,7 +33,7 @@
       "cache_creation_tokens": 200000,
       "cache_read_tokens": 3000000,
       "output_tokens": 30000,
-      "expected_co2_grams": 670.0,
+      "expected_co2_grams": 175.56,
       "expected_cost_usd": 7.5
     },
     {
@@ -44,7 +44,7 @@
       "cache_creation_tokens": 0,
       "cache_read_tokens": 0,
       "output_tokens": 100000,
-      "expected_co2_grams": 800.0,
+      "expected_co2_grams": 243.2,
       "expected_cost_usd": 7.5
     },
     {
@@ -55,7 +55,7 @@
       "cache_creation_tokens": 150000,
       "cache_read_tokens": 12000000,
       "output_tokens": 80000,
-      "expected_co2_grams": 305.9,
+      "expected_co2_grams": 110.15,
       "expected_cost_usd": 5.4225
     },
     {
@@ -66,7 +66,7 @@
       "cache_creation_tokens": 10000,
       "cache_read_tokens": 500000,
       "output_tokens": 20000,
-      "expected_co2_grams": 19.95,
+      "expected_co2_grams": 10.06,
       "expected_cost_usd": 0.2025
     },
     {
@@ -77,7 +77,7 @@
       "cache_creation_tokens": 100000,
       "cache_read_tokens": 0,
       "output_tokens": 0,
-      "expected_co2_grams": 50.0,
+      "expected_co2_grams": 7.8,
       "expected_cost_usd": 0.625
     },
     {
@@ -88,7 +88,7 @@
       "cache_creation_tokens": 0,
       "cache_read_tokens": 1000000,
       "output_tokens": 0,
-      "expected_co2_grams": 15.2,
+      "expected_co2_grams": 3.12,
       "expected_cost_usd": 0.3
     },
     {
@@ -122,7 +122,7 @@
       "cache_creation_tokens": 0,
       "cache_read_tokens": 0,
       "output_tokens": 10000,
-      "expected_co2_grams": 70.0,
+      "expected_co2_grams": 34.6,
       "expected_cost_usd": 0.6
     },
     {
@@ -133,7 +133,7 @@
       "cache_creation_tokens": 400000,
       "cache_read_tokens": 8000000,
       "output_tokens": 60000,
-      "expected_co2_grams": 715.0,
+      "expected_co2_grams": 182.58,
       "expected_cost_usd": 8.15
     },
     {
@@ -144,7 +144,7 @@
       "cache_creation_tokens": 0,
       "cache_read_tokens": 0,
       "output_tokens": 10000,
-      "expected_co2_grams": 6.65,
+      "expected_co2_grams": 4.33,
       "expected_cost_usd": 0.06
     },
     {
@@ -155,7 +155,7 @@
       "cache_creation_tokens": 0,
       "cache_read_tokens": 10000000,
       "output_tokens": 0,
-      "expected_co2_grams": 76.0,
+      "expected_co2_grams": 16.0,
       "expected_cost_usd": 1.0
     }
   ]


### PR DESCRIPTION
## Summary

Two linked workstreams, verified by an adversarial multi-agent review before this PR.

### 1. CO2 factor recalibration (multi-source, cross-validated)
The old Sonnet factors (190/1140) did not reproduce the latest Jegham et al. revision and baked in a stale carbon-intensity. New factors (gCO2e/Mtok, usage-only, AWS region grid 0.287):

| Model | input | output | basis |
|---|---|---|---|
| Sonnet | 39 | 826 | 3-point OLS fit to Jegham v6 (0.950/2.989/5.671 Wh), cross-validated vs EcoLogits |
| Opus | 78 | 1652 | 2x Sonnet (EcoLogits Opus 4.5+ params + price ratio) |
| Haiku | 20 | 413 | 0.5x Sonnet |
| Fable | 156 | 3304 | 2x Opus |

- Relabeled `0.287` as the **AWS region grid (location-based)**, not a "US average" (~380).
- Net effect on stored history (CO2-only recompute): ~795 → ~575 kg.

### 2. Pricing + EUR
USD list prices reconfirmed current (no drift). Added `eur_per_usd` (ECB ref rate 2026-06-22, 0.8729) for display-time conversion; documented the 2x 1-hour cache-write tier.

### 3. Self-update flow (1.0.0 → 1.1.0)
- **Notice**: backgrounded daily version check (`check-update.sh`) → cached flag; statusline shows a network-free `⬆ /carbon-update` (7-day staleness gate, `CLAUDE_CARBON_NO_UPDATE_NOTIFIER` opt-out).
- **Update**: `/carbon-update` slash command + `update.sh`, a dirty-safe `git pull` that stashes the two user-editable data files and preserves edits to `*.local.bak` on conflict.
- **Recompute**: `recompute.sh` now defaults to **CO2-only** (`--with-cost` opt-in), avoiding the mixed-model cost drift; numeric-validates config before SQL interpolation; `.timeout 5000`.

## Verification
Adversarial review (6 dimensions: shell-safety, portability, numeric consistency, docs, update-flow, security) returned 4 must-fix, all fixed and re-proven:
- Stash-conflict recovery now uses `checkout HEAD --` (was leaving conflict markers in data files) — reproduced fix: conflicted file → clean upstream JSON.
- `recompute.sh` refuses non-numeric config (was SQL-injectable via a poisoned `factors.json` auto-run on update) — verified: `DROP TABLE` payload refused, table intact.
- Portable `detach()` (setsid is absent on macOS, so the check never ran there).
- `sort -V` capability guard; CHANGELOG wording.

Deterministic: `bash -n` all scripts, JSON valid, **12/12 golden vectors pass**, recompute default leaves cost byte-identical.
