### PR TITLE
feat: honour CLAUDE_CONFIG_DIR for alternate Claude environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2026-07-21
+
+### feat: honour `CLAUDE_CONFIG_DIR` for second Claude environments (#15)
+
+Claude Code can run out of an alternate config dir (`CLAUDE_CONFIG_DIR=~/.claude-work claude`), but every path in claude-carbon was hardcoded to `~/.claude`, so a second environment could not track itself. All state now resolves against `${CLAUDE_CONFIG_DIR:-$HOME/.claude}`: the settings merge and `/carbon-*` command symlinks (install.sh), the database dir (setup.sh, safety-rescan.sh), the transcript scan and inserts (backfill.sh, persist-session.sh), the re-price and report reads (recompute.sh, generate-report.sh), and the usage cache, credentials lookup and update-notice flag (statusline.sh, check-update.sh, update.sh). Install into the alternate dir by putting the var on the `bash` side of the pipe. Because the hooks and status line inherit `CLAUDE_CONFIG_DIR` from the environment that launched `claude`, each environment writes its own DB. Default behaviour is unchanged when the var is unset. As a side effect `generate-report.sh` now also honours `CLAUDE_CARBON_DB` like the other scripts (previously it ignored it).
+
+### fix: `CLAUDE_CARBON_DIR` install example passed the var to `curl`, not `bash` (#16)
+
+The documented custom-directory one-liner set `CLAUDE_CARBON_DIR=... curl ... | bash`, which scopes the variable to `curl`; the piped `bash` never saw it and installed to the default location. Moved the assignment to the `bash` side of the pipe.
+
 ## 2026-07-20
 
 ### feat: `--until` for closed reporting periods

--- a/README.md
+++ b/README.md
@@ -82,8 +82,29 @@ bash ~/code/claude-carbon/scripts/generate-report.sh --since 2026-01-01 --until 
 <summary>Custom install directory</summary>
 
 ```bash
-CLAUDE_CARBON_DIR=~/my-path/claude-carbon curl -fsSL https://raw.githubusercontent.com/gwittebolle/claude-carbon/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/gwittebolle/claude-carbon/main/install.sh | CLAUDE_CARBON_DIR=~/my-path/claude-carbon bash
 ```
+
+The env var has to sit on the `bash` side of the pipe, not the `curl` side, or the installer never sees it.
+
+</details>
+
+<details>
+<summary>Second Claude environment (CLAUDE_CONFIG_DIR)</summary>
+
+If you run a second Claude Code environment out of its own config directory, e.g.
+
+```bash
+alias claude-work="CLAUDE_CONFIG_DIR=~/.claude-work claude"
+```
+
+install claude-carbon into that same directory by passing `CLAUDE_CONFIG_DIR` to the installer:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/gwittebolle/claude-carbon/main/install.sh | CLAUDE_CONFIG_DIR=~/.claude-work bash
+```
+
+The status line, the Stop hook, the database and the `/carbon-*` commands all live under that config dir, so each environment tracks its own sessions independently. When `CLAUDE_CONFIG_DIR` is unset everything falls back to `~/.claude` as before.
 
 </details>
 

--- a/install.sh
+++ b/install.sh
@@ -5,7 +5,10 @@ set -euo pipefail
 # Usage: curl -fsSL https://raw.githubusercontent.com/gwittebolle/claude-carbon/main/install.sh | bash
 
 INSTALL_DIR="${CLAUDE_CARBON_DIR:-$HOME/code/claude-carbon}"
-SETTINGS_FILE="${HOME}/.claude/settings.json"
+# Honour Claude Code's own CLAUDE_CONFIG_DIR so a second environment
+# (e.g. CLAUDE_CONFIG_DIR=~/.claude-work claude) installs into its own dir.
+CONFIG_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+SETTINGS_FILE="${CONFIG_DIR}/settings.json"
 
 echo ""
 echo "  claude-carbon installer"
@@ -63,7 +66,7 @@ CLAUDE_CARBON_INSTALLER=1 bash "$INSTALL_DIR/scripts/setup.sh"
 
 # 3b. On update, re-price stored history with the new factors (CO2-only; cost left intact).
 if [ "$WAS_UPDATE" = "1" ]; then
-  DB_PATH="${CLAUDE_CARBON_DB:-${HOME}/.claude/claude-carbon/carbon.db}"
+  DB_PATH="${CLAUDE_CARBON_DB:-${CONFIG_DIR}/claude-carbon/carbon.db}"
   if [ -f "$DB_PATH" ]; then
     bash "$INSTALL_DIR/scripts/recompute.sh" || echo "  (history not re-priced; see message above)"
   fi
@@ -73,7 +76,7 @@ fi
 echo ""
 echo "Configuring Claude Code..."
 
-mkdir -p "${HOME}/.claude"
+mkdir -p "$CONFIG_DIR"
 
 STATUSLINE_CMD="${INSTALL_DIR}/scripts/statusline.sh"
 HOOK_CMD="${INSTALL_DIR}/scripts/persist-session.sh"
@@ -134,7 +137,7 @@ else
 fi
 
 # 5. Install /carbon-report slash command
-COMMANDS_DIR="${HOME}/.claude/commands"
+COMMANDS_DIR="${CONFIG_DIR}/commands"
 SKILL_SOURCE="${INSTALL_DIR}/skills/carbon-report/SKILL.md"
 SKILL_LINK="${COMMANDS_DIR}/carbon-report.md"
 

--- a/scripts/backfill.sh
+++ b/scripts/backfill.sh
@@ -11,7 +11,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FACTORS_FILE="${SCRIPT_DIR}/../data/factors.json"
 PRICES_FILE="${SCRIPT_DIR}/../data/prices.json"
-DB_PATH="${CLAUDE_CARBON_DB:-${HOME}/.claude/claude-carbon/carbon.db}"
+CONFIG_DIR="${CLAUDE_CONFIG_DIR:-${HOME}/.claude}"
+DB_PATH="${CLAUDE_CARBON_DB:-${CONFIG_DIR}/claude-carbon/carbon.db}"
 
 # Rows written by this version of the methodology (raw-token columns populated).
 METHODOLOGY_VERSION=2
@@ -196,7 +197,7 @@ compute_co2_cost() {
   echo "$total_input $cw $cr $out $co2 $cost"
 }
 
-# Scan all JSONL files under ~/.claude/projects/, max 2 levels deep
+# Scan all JSONL files under $CONFIG_DIR/projects/, max 2 levels deep
 # Exclude subagents/ and vercel-plugin/ directories (subagents are handled per session)
 while IFS= read -r JSONL_FILE; do
   # Skip files in excluded directories
@@ -294,6 +295,6 @@ while IFS= read -r JSONL_FILE; do
 
   ADDED=$((ADDED + 1))
 
-done < <(find "${HOME}/.claude/projects" -maxdepth 2 -name "*.jsonl" 2>/dev/null)
+done < <(find "${CONFIG_DIR}/projects" -maxdepth 2 -name "*.jsonl" 2>/dev/null)
 
 echo "  Backfill complete: ${ADDED} sessions added, ${SKIPPED} skipped, ${ERRORS} errors."

--- a/scripts/check-update.sh
+++ b/scripts/check-update.sh
@@ -6,7 +6,7 @@
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_DIR="$(dirname "$SCRIPT_DIR")"
-STATE_DIR="${HOME}/.claude/claude-carbon"
+STATE_DIR="${CLAUDE_CONFIG_DIR:-${HOME}/.claude}/claude-carbon"
 OUT="${STATE_DIR}/update-check.json"
 
 # Opt-out (mirrors npm/gh NO_UPDATE_NOTIFIER convention)

--- a/scripts/generate-report.sh
+++ b/scripts/generate-report.sh
@@ -9,7 +9,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 TEMPLATE_DIR="$PROJECT_DIR/templates"
 EXPORT_DIR="$PROJECT_DIR/exports"
-DB_PATH="${HOME}/.claude/claude-carbon/carbon.db"
+DB_PATH="${CLAUDE_CARBON_DB:-${CLAUDE_CONFIG_DIR:-${HOME}/.claude}/claude-carbon/carbon.db}"
 TODAY="$(date +%Y-%m-%d)"
 YEAR="$(date +%Y)"
 

--- a/scripts/persist-session.sh
+++ b/scripts/persist-session.sh
@@ -10,7 +10,8 @@
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FACTORS_FILE="${SCRIPT_DIR}/../data/factors.json"
 PRICES_FILE="${SCRIPT_DIR}/../data/prices.json"
-DB_PATH="${CLAUDE_CARBON_DB:-${HOME}/.claude/claude-carbon/carbon.db}"
+CONFIG_DIR="${CLAUDE_CONFIG_DIR:-${HOME}/.claude}"
+DB_PATH="${CLAUDE_CARBON_DB:-${CONFIG_DIR}/claude-carbon/carbon.db}"
 
 METHODOLOGY_VERSION=2
 
@@ -171,7 +172,7 @@ JSONL_FILE=""
 if [ -n "$TRANSCRIPT_PATH" ] && [ -f "$TRANSCRIPT_PATH" ]; then
   JSONL_FILE="$TRANSCRIPT_PATH"
 else
-  for DIR in "${HOME}/.claude/projects"/*; do
+  for DIR in "${CONFIG_DIR}/projects"/*; do
     [ -d "$DIR" ] || continue
     CANDIDATE="${DIR}/${SESSION_ID}.jsonl"
     if [ -f "$CANDIDATE" ]; then

--- a/scripts/recompute.sh
+++ b/scripts/recompute.sh
@@ -20,7 +20,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FACTORS_FILE="${CLAUDE_CARBON_FACTORS:-${SCRIPT_DIR}/../data/factors.json}"
 PRICES_FILE="${CLAUDE_CARBON_PRICES:-${SCRIPT_DIR}/../data/prices.json}"
-DB_PATH="${CLAUDE_CARBON_DB:-${HOME}/.claude/claude-carbon/carbon.db}"
+DB_PATH="${CLAUDE_CARBON_DB:-${CLAUDE_CONFIG_DIR:-${HOME}/.claude}/claude-carbon/carbon.db}"
 
 [ -f "$DB_PATH" ] || { echo "No database at ${DB_PATH}" >&2; exit 1; }
 

--- a/scripts/safety-rescan.sh
+++ b/scripts/safety-rescan.sh
@@ -6,7 +6,7 @@
 # Must exit 0 immediately and never block session start.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-DB_DIR="${HOME}/.claude/claude-carbon"
+DB_DIR="${CLAUDE_CONFIG_DIR:-${HOME}/.claude}/claude-carbon"
 DB_PATH="${CLAUDE_CARBON_DB:-${DB_DIR}/carbon.db}"
 STAMP="${DB_DIR}/.last-rescan"
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -5,7 +5,8 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PLUGIN_DIR="$(dirname "$SCRIPT_DIR")"
-DB_DIR="${HOME}/.claude/claude-carbon"
+CONFIG_DIR="${CLAUDE_CONFIG_DIR:-${HOME}/.claude}"
+DB_DIR="${CONFIG_DIR}/claude-carbon"
 DB_PATH="${DB_DIR}/carbon.db"
 
 echo "🌿 claude-carbon setup"
@@ -101,7 +102,7 @@ if [ "${CLAUDE_CARBON_INSTALLER:-}" != "1" ]; then
   echo "─────────────────────────────"
   echo "Next steps:"
   echo ""
-  echo "1. Add to ~/.claude/settings.json:"
+  echo "1. Add to ${CONFIG_DIR}/settings.json:"
   echo ""
   cat <<EOF
 {

--- a/scripts/statusline.sh
+++ b/scripts/statusline.sh
@@ -11,6 +11,7 @@ SEGMENT_MODE=0
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FACTORS_FILE="${SCRIPT_DIR}/../data/factors.json"
+CONFIG_DIR="${CLAUDE_CONFIG_DIR:-${HOME}/.claude}"
 
 # Read stdin
 INPUT="$(cat)"
@@ -99,7 +100,7 @@ if command -v jq &>/dev/null; then
 
   # Priority 2: fallback to GET /api/oauth/usage with 60s cache.
   if [ -z "$FIVE_PCT" ]; then
-    USAGE_CACHE_DIR="${HOME}/.claude/claude-carbon"
+    USAGE_CACHE_DIR="${CONFIG_DIR}/claude-carbon"
     USAGE_CACHE_FILE="${USAGE_CACHE_DIR}/oauth-usage.json"
     USAGE_CACHE_TTL=60
     mkdir -p "$USAGE_CACHE_DIR"
@@ -120,7 +121,7 @@ if command -v jq &>/dev/null; then
         [ -n "$BLOB" ] && TOKEN="$(echo "$BLOB" | jq -r '.claudeAiOauth.accessToken // empty' 2>/dev/null)"
       fi
       if [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ]; then
-        CREDS="${HOME}/.claude/.credentials.json"
+        CREDS="${CONFIG_DIR}/.credentials.json"
         [ -f "$CREDS" ] && TOKEN="$(jq -r '.claudeAiOauth.accessToken // empty' "$CREDS" 2>/dev/null)"
       fi
 
@@ -201,7 +202,7 @@ fi
 # (SessionStart hook → check-update.sh) and writes a cached flag; here we only read it. A 7-day
 # staleness gate means an abandoned flag (background check stopped) self-clears.
 UPDATE_SEGMENT=""
-UPD_FILE="${HOME}/.claude/claude-carbon/update-check.json"
+UPD_FILE="${CONFIG_DIR}/claude-carbon/update-check.json"
 if [ -z "${CLAUDE_CARBON_NO_UPDATE_NOTIFIER:-}" ] && [ -f "$UPD_FILE" ] && command -v jq &>/dev/null; then
   if [ "$(jq -r '.behind // false' "$UPD_FILE" 2>/dev/null)" = "true" ]; then
     UPD_AT="$(jq -r '.checked_at // 0' "$UPD_FILE" 2>/dev/null || echo 0)"

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -7,7 +7,7 @@ set -uo pipefail   # NOT -e: each git step is handled explicitly
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_DIR="$(dirname "$SCRIPT_DIR")"
-STATE_DIR="${HOME}/.claude/claude-carbon"
+STATE_DIR="${CLAUDE_CONFIG_DIR:-${HOME}/.claude}/claude-carbon"
 
 [ -d "${REPO_DIR}/.git" ] || { echo "Not a git-clone install; nothing to update." >&2; exit 0; }
 case "$REPO_DIR" in


### PR DESCRIPTION
## What

Makes claude-carbon aware of Claude Code's own `CLAUDE_CONFIG_DIR`, so a second environment (e.g. `alias claude-work="CLAUDE_CONFIG_DIR=~/.claude-work claude"`) can install and track itself independently. Also fixes a broken install one-liner in the README.

Closes #15
Closes #16

## Why

Every path was hardcoded to `~/.claude`. With `CLAUDE_CONFIG_DIR` set, Claude Code stores its settings, commands, transcripts and credentials elsewhere, so claude-carbon wrote its statusline/hook config and DB to the wrong place and scanned the wrong `projects/` dir.

## Changes

All state now resolves against `${CLAUDE_CONFIG_DIR:-$HOME/.claude}`:

| Area | Files |
|---|---|
| settings merge + `/carbon-*` symlinks | `install.sh` |
| database dir | `setup.sh`, `safety-rescan.sh` |
| transcript scan + inserts | `backfill.sh`, `persist-session.sh` |
| re-price + report reads | `recompute.sh`, `generate-report.sh` |
| usage cache, credentials, update flag | `statusline.sh`, `check-update.sh`, `update.sh` |

- Priority for the DB path is `CLAUDE_CARBON_DB` > `CLAUDE_CONFIG_DIR` > `~/.claude`.
- `generate-report.sh` now also honours `CLAUDE_CARBON_DB` (previously ignored it).
- Default behaviour is unchanged when `CLAUDE_CONFIG_DIR` is unset.
- The marketplace guard (`*/.claude/plugins/*`) is untouched: marketplace installs do not run `install.sh`.

### #16 fix

The custom-directory one-liner set the env var on the `curl` side of the pipe, where the piped `bash` never saw it. Moved it to the `bash` side.

## Verification

- `bash -n` on all 10 scripts; 12/12 methodology vectors pass (no factor/price change).
- `install.sh` end-to-end in an isolated sandbox (fake `$HOME`, offline): install into an alt config dir puts DB + settings + command symlinks under it, points the statusline/Stop hook at the install dir, writes **nothing** under `~/.claude`; re-run is idempotent (no duplicate hooks); with the var unset everything lands under `~/.claude` as before.
- Runtime Stop-hook path (`persist-session.sh` driven with real stdin JSON): writes to the alt DB via `transcript_path`, and its fallback scan finds sessions under the alt `projects/`; `generate-report` resolves the alt DB.