### PR TITLE
fix(skills): honour CLAUDE_CONFIG_DIR / CLAUDE_CARBON_DIR in carbon-* invocations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2026-07-22
+
+### fix: skill invocations ignored `CLAUDE_CONFIG_DIR` / `CLAUDE_CARBON_DIR` (#15, #16)
+
+The path sweep that taught the installer and scripts to honour `CLAUDE_CONFIG_DIR` and `CLAUDE_CARBON_DIR` never touched `skills/`, so the bash embedded in three SKILL.md files still pointed at the default `~/.claude` and `~/code/claude-carbon`. On a second environment (`CLAUDE_CONFIG_DIR=~/.claude-work`) or a custom install dir, `/carbon-card`, `/carbon-report` and `/carbon-update` read or wrote the wrong location. They now resolve paths the same way the scripts do: `carbon-report` reads the DB from `${CLAUDE_CARBON_DB:-${CLAUDE_CONFIG_DIR:-$HOME/.claude}/claude-carbon/carbon.db}` and points its setup hint at `${CLAUDE_CARBON_DIR:-$HOME/code/claude-carbon}`; `carbon-update` reads `settings.json` from `${CLAUDE_CONFIG_DIR:-$HOME/.claude}`; `carbon-card` locates the install from the status-line command (falling back to `CLAUDE_PLUGIN_ROOT`, then `CLAUDE_CARBON_DIR`) instead of the hardcoded default. Default behaviour is unchanged when neither variable is set.
+
 ## 2026-07-21
 
 ### feat: honour `CLAUDE_CONFIG_DIR` for second Claude environments (#15)

--- a/skills/carbon-card/SKILL.md
+++ b/skills/carbon-card/SKILL.md
@@ -3,10 +3,22 @@ name: carbon-card
 description: Generate shareable PNG report cards of your Claude Code carbon footprint
 ---
 
-Run the following bash command and present the output to the user. Show the exported file paths so they can share the PNGs.
+Run the following bash script and present the output to the user. Show the exported file paths so they can share the PNGs.
 
 ```bash
-bash ~/code/claude-carbon/scripts/generate-report.sh
+#!/usr/bin/env bash
+# Locate the install wired into the status line (honours CLAUDE_CONFIG_DIR),
+# then fall back to CLAUDE_PLUGIN_ROOT / CLAUDE_CARBON_DIR / the default path.
+CFG="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+REPO_DIR=""
+if command -v jq >/dev/null 2>&1 && [ -f "$CFG/settings.json" ]; then
+  SL_CMD="$(jq -r '.statusLine.command // empty' "$CFG/settings.json" 2>/dev/null)"
+  [ -n "$SL_CMD" ] && [ -f "$SL_CMD" ] && REPO_DIR="$(cd "$(dirname "$SL_CMD")/.." 2>/dev/null && pwd)"
+fi
+[ -z "$REPO_DIR" ] && [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && REPO_DIR="$CLAUDE_PLUGIN_ROOT"
+[ -z "$REPO_DIR" ] && REPO_DIR="${CLAUDE_CARBON_DIR:-$HOME/code/claude-carbon}"
+
+bash "$REPO_DIR/scripts/generate-report.sh"
 ```
 
-After the script completes, tell the user where the PNGs were exported (in `~/code/claude-carbon/exports/`).
+The script prints the export directory on its final line (`Done. <dir>/`). Show that path to the user so they can share the PNGs.

--- a/skills/carbon-report/SKILL.md
+++ b/skills/carbon-report/SKILL.md
@@ -12,11 +12,11 @@ Run the following bash script exactly as written and present the output to the u
 # "431.7045" as 431 and print "431,0" instead of "431.7"
 export LC_ALL=C
 
-DB_PATH="${HOME}/.claude/claude-carbon/carbon.db"
+DB_PATH="${CLAUDE_CARBON_DB:-${CLAUDE_CONFIG_DIR:-$HOME/.claude}/claude-carbon/carbon.db}"
 
 if [ ! -f "$DB_PATH" ]; then
   echo "Database not found. Run setup.sh first:"
-  echo "  bash ~/code/claude-carbon/scripts/setup.sh"
+  echo "  bash ${CLAUDE_CARBON_DIR:-$HOME/code/claude-carbon}/scripts/setup.sh"
   exit 1
 fi
 

--- a/skills/carbon-update/SKILL.md
+++ b/skills/carbon-update/SKILL.md
@@ -9,7 +9,7 @@ Run the following bash script exactly as written and present its output to the u
 #!/usr/bin/env bash
 # Locate the install that is actually wired into the status line, then run its updater.
 REPO_DIR=""
-SETTINGS="${HOME}/.claude/settings.json"
+SETTINGS="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/settings.json"
 if command -v jq >/dev/null 2>&1 && [ -f "$SETTINGS" ]; then
   SL_CMD="$(jq -r '.statusLine.command // empty' "$SETTINGS" 2>/dev/null)"
   if [ -n "$SL_CMD" ] && [ -f "$SL_CMD" ]; then


### PR DESCRIPTION
## Context

#17 taught the installer and every script to resolve paths against `CLAUDE_CONFIG_DIR` and `CLAUDE_CARBON_DIR`, and it closed #15 and #16. Its sweep only covered `install.sh` and `scripts/`, though. The bash embedded in the `skills/*/SKILL.md` files carries its own path logic and was never updated, so three skills still pointed at the default `~/.claude` and `~/code/claude-carbon`. On a second environment (`CLAUDE_CONFIG_DIR=~/.claude-work`) or a custom install dir, `/carbon-card`, `/carbon-report` and `/carbon-update` read or wrote the wrong location. This is the follow-up flagged on both issues.

## Changes

- **carbon-report** reads the DB from `${CLAUDE_CARBON_DB:-${CLAUDE_CONFIG_DIR:-$HOME/.claude}/claude-carbon/carbon.db}` (same convention as the scripts) and points its `setup.sh` hint at `${CLAUDE_CARBON_DIR:-$HOME/code/claude-carbon}`.
- **carbon-update** reads `settings.json` from `${CLAUDE_CONFIG_DIR:-$HOME/.claude}`.
- **carbon-card** locates the install from the status-line command in `$CFG/settings.json`, falling back to `CLAUDE_PLUGIN_ROOT`, then `CLAUDE_CARBON_DIR`, then the default, and defers the export-dir message to the script's own final line.
- CHANGELOG entry.

Default behaviour is unchanged when neither variable is set.

## Verification

- Resolver snippets tested across 12 cases: default, `CLAUDE_CONFIG_DIR` set, `CLAUDE_CARBON_DB` priority, status-line discovery under a custom config dir, `CLAUDE_PLUGIN_ROOT` / `CLAUDE_CARBON_DIR` fallbacks, and a stale status-line path falling through cleanly. All pass.
- `bash -n` clean on all three skill blocks.
- Repo-wide sweep confirms no remaining functional hardcodes outside a non-functional comment in `check-update.sh`.

Refs #15 #16