### PR TITLE
feat: add beef steak equivalence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2026-08-12
+
+### feat: add beef steak equivalence
+
+Meat, and especially red meat, is one of the worst pollution sources.
+Add steak equivalence to give another comparison, offer a broader representation of the order of magnitude, and promote vegetarian diets.
+
 ## 2026-08-03
 
 ### fix: a hook already present under a different spelling was added twice

--- a/METHODOLOGY.md
+++ b/METHODOLOGY.md
@@ -117,10 +117,11 @@ For EUR, `data/prices.json` carries `eur_per_usd` (ECB euro reference rate, 0.87
 
 ## Equivalences used in reports
 
-| Activity                 | Emission factor | Source                                             |
-| ------------------------ | --------------- | -------------------------------------------------- |
-| Car (thermal, lifecycle) | 142 gCO2e/km    | ADEME Impact CO2, 2025 car footprint model         |
-| Median Gemini prompt     | 0.03 gCO2e      | Google, Aug 2025 (arXiv:2508.15734)                |
-| TGV (full scope)         | 3.5 gCO2e/km    | SNCF open data 2024, per passenger-km              |
+| Activity                 | Emission factor  | Source                                     |
+| ------------------------ | ---------------- | ------------------------------------------ |
+| Car (thermal, lifecycle) | 142 gCO2e/km     | ADEME Impact CO2, 2025 car footprint model |
+| Median Gemini prompt     | 0.03 gCO2e       | Google, Aug 2025 (arXiv:2508.15734)        |
+| TGV (full scope)         | 3.5 gCO2e/km     | SNCF open data 2024, per passenger-km      |
+| Beef steak (150g)        | 4340 gCO2e/steak | ADEME Impact CO2 (Agribalyse 3.2), 2025    |
 
-Car and TGV factors are lifecycle values while this tool's CO2 is usage-only; the equivalences are illustrative, not scope-matched. Refreshed 2026-07-31: earlier releases used 120 g/km (car, close to the EU new-vehicle homologation average, misattributed to ADEME), 0.2 g per Google search (a 2009 blog figure misattributed to the 2023 environmental report), 19 g per email with attachment (ADEME 2011, withdrawn; the current ADEME reference email is ~2.5 g) and 2.4 g/km (TGV, untraceable).
+Car, TGV, and steak factors are lifecycle values while this tool's CO2 is usage-only; the equivalences are illustrative, not scope-matched. Refreshed 2026-07-31: earlier releases used 120 g/km (car, close to the EU new-vehicle homologation average, misattributed to ADEME), 0.2 g per Google search (a 2009 blog figure misattributed to the 2023 environmental report), 19 g per email with attachment (ADEME 2011, withdrawn; the current ADEME reference email is ~2.5 g) and 2.4 g/km (TGV, untraceable).

--- a/skills/carbon-report/SKILL.md
+++ b/skills/carbon-report/SKILL.md
@@ -44,6 +44,7 @@ ALL_COST="$(sqlite3 "$DB_PATH" "SELECT COALESCE(SUM(cost_usd), 0) FROM sessions 
 KM_CAR="$(echo "$ALL_CO2" | awk '{printf "%.0f", $1 / 142}')"
 GEMINI="$(echo "$ALL_CO2" | awk '{printf "%.0f", $1 / 0.03}')"
 KM_TGV="$(echo "$ALL_CO2" | awk '{printf "%.0f", $1 / 3.5}')"
+STEAKS="$(echo "$ALL_CO2" | awk '{printf "%.0f", $1 / 4340}')"
 
 # --- Top 5 sessions by CO2 ---
 TOP5="$(sqlite3 -separator '|' "$DB_PATH" \
@@ -82,6 +83,7 @@ echo "--- Equivalences (all-time) ---"
 echo "  ${KM_CAR} km en voiture        (142 gCO2e/km, ADEME 2025)"
 echo "  ${GEMINI} prompts Gemini       (0.03 gCO2e, Google 2025)"
 echo "  ${KM_TGV} km en TGV             (3.5 gCO2e/km, SNCF 2024)"
+echo "  ${STEAKS} steaks de boeuf        (4340 gCO2e/steak 150g, ADEME/Agribalyse 2025)"
 echo ""
 echo "--- Top 5 sessions by CO2 ---"
 echo "Date        | Project                 | CO2 (g) | Model                          | Cost"


### PR DESCRIPTION
# Summary

Meat, and especially red meat, is one of the worst pollution sources.
Add steak equivalence to give another comparison, offer a broader representation of the order of magnitude, and promote vegetarian diets.

## Checklist

- [x] `bash tests/run-vectors.sh` passes locally
- [x] Commits follow the conventional format (`feat:`, `fix:`, `docs:`, ...)
- [x] `CHANGELOG.md` has a date-stamped entry for this change
- [x] README updated if the change is user-visible

### Only if `data/factors.json` or `data/prices.json` changed

- [ ] `tests/methodology-vectors.json` updated with the new expected outputs
- [x] `METHODOLOGY.md` updated, every new number reproducible from a cited source
