### PR TITLE
fix: install drift check ignores documentation-only edits to data files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2026-08-22
+
+- fix: the statusline's "install drift" check no longer fires on documentation-only edits. It compared `data/factors.json` and `data/prices.json` byte for byte against the newest plugin cache copy, so changing a `_`-prefixed comment key (17d396a rewrote `_cache_read_factor`, value unchanged) lit the segment on two-install machines. The byte `cmp` stays as the fast path; only when it differs does a `jq` pass strip every `_`-prefixed key at any depth and compare the remaining values. Value changes (top-level or nested) still flag. Single-install machines are unaffected, the check still self-skips there. Covered by five new cases in `tests/run-install-tests.sh`.
+
 ## 2026-08-21
 
 - docs: the cache_read_factor section now says what the term actually is. The formula applies a fraction of an uncached input token, so it is a PREFILL residual; earlier versions justified it as the decode-phase KV re-read residual, which is a different object, bilinear in (context x generated tokens) and currently absorbed in the output factor. Consequence stated: long-context agentic use is underestimated. Adds the Irminsul hit/miss measurement (arXiv:2605.05696, Table 1: 14/34/37% on GQA/MHA/MLA at 4096 prefix tokens), explains why 0.14 is not adopted, and widens the published range from 0.05-0.15 to 0.05-0.20 because two of the three measured architectures sit above the old ceiling. The factor value itself is unchanged at 0.08, so all 12 golden vectors are untouched.

--- a/scripts/statusline.sh
+++ b/scripts/statusline.sh
@@ -222,9 +222,22 @@ fi
 # factors while every check runs green on the current copy (incident of 2026-08-01: six weeks
 # of sessions persisted with pre-v6 factors). Auto-update is opt-in for third-party
 # marketplaces, so the cache CAN lag. Here we compare this install's factors/prices against
-# the newest cached copy of the plugin; any byte difference means the two installs disagree.
-# Self-skips when this statusline IS the newest cache copy (single-install machines).
+# the newest cached copy of the plugin. Fast path: one cmp per file, no spawn when the bytes
+# match (the common case). Only when they differ do we spend a jq to compare the data with
+# the "_"-prefixed documentation keys stripped: a docs-only edit to a comment key (the
+# 2026-08-22 false positive, 17d396a) must not look like a factor change, while any value
+# difference still does. Self-skips when this statusline IS the newest cache copy
+# (single-install machines).
 DRIFT_SEGMENT=""
+# drift_values_differ <a> <b>: 0 when the two JSON files disagree once every "_"-prefixed
+# key (at any depth) is removed; 1 when they agree. Without jq, any byte difference counts.
+drift_values_differ() {
+  command -v jq &>/dev/null || return 0
+  local A B
+  A="$(jq -S 'walk(if type == "object" then with_entries(select(.key | startswith("_") | not)) else . end)' "$1" 2>/dev/null)" || return 0
+  B="$(jq -S 'walk(if type == "object" then with_entries(select(.key | startswith("_") | not)) else . end)' "$2" 2>/dev/null)" || return 0
+  [ "$A" != "$B" ]
+}
 if [ -z "${CLAUDE_CARBON_NO_DRIFT_CHECK:-}" ] && printf '1.0\n1.0.1\n' | sort -V >/dev/null 2>&1; then
   CACHE_LATEST=""
   for D in "${CONFIG_DIR}/plugins/cache"/*/claude-carbon/*/; do
@@ -239,7 +252,8 @@ if [ -z "${CLAUDE_CARBON_NO_DRIFT_CHECK:-}" ] && printf '1.0\n1.0.1\n' | sort -V
     if [ -n "$OWN_ROOT" ] && [ -n "$CACHE_ROOT" ] && [ "$OWN_ROOT" != "$CACHE_ROOT" ]; then
       for F in data/factors.json data/prices.json; do
         if [ -f "${CACHE_ROOT}/${F}" ] && [ -f "${OWN_ROOT}/${F}" ] \
-           && ! cmp -s "${CACHE_ROOT}/${F}" "${OWN_ROOT}/${F}"; then
+           && ! cmp -s "${CACHE_ROOT}/${F}" "${OWN_ROOT}/${F}" \
+           && drift_values_differ "${CACHE_ROOT}/${F}" "${OWN_ROOT}/${F}"; then
           DRIFT_SEGMENT=" | ≠ install drift"
           break
         fi
@@ -283,3 +297,4 @@ if [ -z "${CLAUDE_CARBON_NO_CARD_NUDGE:-}" ]; then
 fi
 
 echo "${PROJECT}${BRANCH_SUFFIX} | ${DOT} ${DISPLAY_NAME} ${PROGRESS_BAR} ${PCT_DISPLAY} | \$${COST_DISPLAY} · ${CO2_DISPLAY}${USAGE_SEGMENT}${UPDATE_SEGMENT}${DRIFT_SEGMENT}${CARD_SEGMENT}"
+

--- a/tests/run-install-tests.sh
+++ b/tests/run-install-tests.sh
@@ -209,6 +209,38 @@ BEFORE="$(cat "${CFG}/settings.json")"
 CLAUDE_CONFIG_DIR="$CFG" bash "$CONFIGURE" >/dev/null 2>&1
 check "invalid settings.json left untouched" "$BEFORE" "$(cat "${CFG}/settings.json")"
 
+# ---------------------------------------------------------------- 9. install drift check
+
+# The statusline compares this install's data/ files against the newest plugin cache copy.
+# A docs-only edit to a "_"-prefixed comment key must stay quiet (false positive of
+# 2026-08-22); a changed value must light the segment; an identical cache stays quiet.
+CFG="${TMPROOT}/drift"
+CACHE_DATA="${CFG}/plugins/cache/mkt/claude-carbon/9.9.9/data"
+mkdir -p "$CACHE_DATA" "${CFG}/claude-carbon"
+cp "${REPO_DIR}/data/prices.json" "${CACHE_DATA}/prices.json"
+
+# drift_shown: "yes" when the statusline prints the drift segment for the current cache.
+drift_shown() {
+  if echo '{}' | CLAUDE_CONFIG_DIR="$CFG" CLAUDE_CARBON_NO_CARD_NUDGE=1 CLAUDE_CARBON_NO_UPDATE_NOTIFIER=1 \
+       bash "$STATUSLINE" 2>/dev/null | grep -q "install drift"; then echo yes; else echo no; fi
+}
+
+cp "${REPO_DIR}/data/factors.json" "${CACHE_DATA}/factors.json"
+check "drift: identical cache is quiet" "no" "$(drift_shown)"
+
+jq '._cache_read_factor = "an older wording of the same comment"' "${REPO_DIR}/data/factors.json" > "${CACHE_DATA}/factors.json"
+check "drift: comment-only difference is quiet" "no" "$(drift_shown)"
+
+jq '.cache_read_factor = (.cache_read_factor + 0.01)' "${REPO_DIR}/data/factors.json" > "${CACHE_DATA}/factors.json"
+check "drift: value difference is flagged" "yes" "$(drift_shown)"
+
+cp "${REPO_DIR}/data/factors.json" "${CACHE_DATA}/factors.json"
+jq '.models.sonnet.input = (.models.sonnet.input + 1)' "${REPO_DIR}/data/prices.json" > "${CACHE_DATA}/prices.json"
+check "drift: nested price difference is flagged" "yes" "$(drift_shown)"
+
+cp "${REPO_DIR}/data/prices.json" "${CACHE_DATA}/prices.json"
+check "drift: CLAUDE_CARBON_NO_DRIFT_CHECK honoured" "no" "$(CLAUDE_CARBON_NO_DRIFT_CHECK=1 drift_shown)"
+
 # ----------------------------------------------------------------
 
 echo ""


### PR DESCRIPTION
## Why

The statusline's `≠ install drift` segment compared `data/factors.json` and `data/prices.json` byte for byte against the newest plugin cache copy. Commit 17d396a rewrote the `_cache_read_factor` comment key (value unchanged), so two-install machines (git clone hosting the statusline + marketplace cache running the hooks) showed a drift that was not one.

## What

- `scripts/statusline.sh`: `cmp` stays the fast path (no spawn when bytes match). Only when they differ, a `jq` pass strips every `_`-prefixed key at any depth and compares the remaining values. Value changes, top-level or nested, still flag. Without jq, any byte difference still counts.
- `tests/run-install-tests.sh`: section 9, five cases (identical cache, comment-only diff, value diff, nested price diff, `CLAUDE_CARBON_NO_DRIFT_CHECK`). The comment-only case fails against the previous script.
- CHANGELOG entry.

Single-install machines are unaffected: the check self-skips there as before.