### PR TITLE
fix: totals in kilograms until 10 t, projections in tonnes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## 2026-08-24
 
+### fix: totals stay in kilograms until 10 t, projections stay in tonnes
+
+The card hero read "1.0 t of estimated CO2" for a total of 1016.5 kg. The tonne tier started at 1 t, so the first real milestone a heavy user reaches is also the point where the number shrinks to a single significant digit and stops reading as a quantity. `format_co2` now switches to tonnes at 10 t; the same total renders as "1016.5 kg". This is one shared function, so the card, the badge, `/carbon-report` and `/carbon-pr` all move together.
+
+The yearly projection deliberately does **not** follow that rule and keeps its own unit. It is an extrapolation from a daily average, and "1414 - 1686 kgCO2/yr" claims four digits of precision the method does not have; tonnes with one decimal state the same range at the resolution actually supported. Below 0.1 t the tonne tier would collapse to "0.0 - 0.1", so light users fall back to whole kilograms. Both bounds always share a unit, picked on the high end, so a range can never straddle a tier boundary.
+
+`{{PROJECTION_UNIT}}` is a new slot in `report-summary.html` and `report-summary-en.html`, since the unit was hardcoded next to the value.
+
+- `tests/run-badge-tests.sh`: the tonne-tier fixture moves from 1.234 t to 12.34 t, a case pins that 1.234 t still renders as kilograms, and `format_co2` gains boundary assertions on both sides of 10 t (17 assertions).
+
+## 2026-08-24
+
 ### docs: recompute.sh understated what it does to mixed-model rows
 
 `recompute.sh` warned that re-pricing collapses mixed-model sessions to the row's dominant model, "~6% high on subagent sessions", and said nothing at all about CO2. Both halves were wrong. Measured while applying the cache-write TTL fix to a real database: over 226 rows, `--with-cost` moved cost from $7,491 to $10,787 (+44%) and CO2 from 194.3 to 225.2 kg (+16%). A session that fans work out to Haiku subagents and carries Fable as its dominant model gets every one of those tokens re-derived at Fable's rate.

--- a/scripts/format-lib.sh
+++ b/scripts/format-lib.sh
@@ -5,10 +5,19 @@
 # pin it anyway so a stray comma-decimal locale cannot corrupt the output.
 
 # Echoes "<value> <unit>" for a gram amount, unit adapting to the magnitude:
-# "432 g", "12.4 kg", "1.2 t". One decimal above the gram tier.
+# "432 g", "12.4 kg", "1240.0 kg", "12.4 t". One decimal above the gram tier.
+#
+# The tonne tier starts at 10 t, not 1 t. A year of heavy Claude Code use lands
+# around one tonne, and "1.0 t" reads as a rounding artefact next to "1016.3 kg";
+# the small number undersells the quantity it stands for. Staying in kilograms
+# until 10 t keeps the figure legible as a quantity for every plausible personal
+# and small-team total, and the tonne tier is left for fleet-scale numbers where
+# four or five digits of kilograms would be the harder read.
+TONNE_TIER_GRAMS=10000000
+
 format_co2() {
   local grams="$1"
-  if (( $(echo "$grams >= 1000000" | LC_ALL=C bc -l) )); then
+  if (( $(echo "$grams >= ${TONNE_TIER_GRAMS}" | LC_ALL=C bc -l) )); then
     echo "$(echo "$grams" | LC_ALL=C awk '{printf "%.1f", $1/1000000}') t"
   elif (( $(echo "$grams >= 1000" | LC_ALL=C bc -l) )); then
     echo "$(echo "$grams" | LC_ALL=C awk '{printf "%.1f", $1/1000}') kg"

--- a/scripts/generate-report.sh
+++ b/scripts/generate-report.sh
@@ -197,8 +197,9 @@ else
   DAYS_ELAPSED=0
 fi
 if [ "$DAYS_ELAPSED" -gt 0 ]; then
-  # Linear: average daily rate extrapolated (in tCO2 with 1 decimal)
-  PROJ_LINEAR="$(echo "$TOTAL_CO2_RAW $DAYS_ELAPSED" | LC_ALL=C awk '{printf "%.1f", ($1 / $2) * 365 / 1000000}')"
+  # Linear: average daily rate extrapolated. Kept in GRAMS so the range can pick
+  # its unit with the same rule as every other figure (see format-lib.sh).
+  PROJ_LINEAR="$(echo "$TOTAL_CO2_RAW $DAYS_ELAPSED" | LC_ALL=C awk '{printf "%.4f", ($1 / $2) * 365}')"
 
   # Trend: last 30 days daily rate extrapolated
   if [ -n "$WHERE" ]; then
@@ -211,7 +212,7 @@ if [ "$DAYS_ELAPSED" -gt 0 ]; then
   LAST_MONTH_END="$(echo "$LAST_MONTH_DATA" | LC_ALL=C awk '{print $3}' | cut -c1-10)"
   LAST_MONTH_DAYS="$(( ( $(date -j -f "%Y-%m-%d" "${LAST_MONTH_END}" +%s 2>/dev/null || date -d "${LAST_MONTH_END}" +%s 2>/dev/null) - $(date -j -f "%Y-%m-%d" "${LAST_MONTH_START}" +%s 2>/dev/null || date -d "${LAST_MONTH_START}" +%s 2>/dev/null) ) / 86400 ))"
   if [ "$LAST_MONTH_DAYS" -gt 0 ]; then
-    PROJ_TREND="$(echo "$LAST_MONTH_CO2 $LAST_MONTH_DAYS" | LC_ALL=C awk '{printf "%.1f", ($1 / $2) * 365 / 1000000}')"
+    PROJ_TREND="$(echo "$LAST_MONTH_CO2 $LAST_MONTH_DAYS" | LC_ALL=C awk '{printf "%.4f", ($1 / $2) * 365}')"
   else
     PROJ_TREND="$PROJ_LINEAR"
   fi
@@ -219,9 +220,27 @@ if [ "$DAYS_ELAPSED" -gt 0 ]; then
   # Sort low-high for display (compare as floats)
   LOW="$(echo "$PROJ_LINEAR $PROJ_TREND" | LC_ALL=C awk '{if ($1 <= $2) print $1; else print $2}')"
   HIGH="$(echo "$PROJ_LINEAR $PROJ_TREND" | LC_ALL=C awk '{if ($1 >= $2) print $1; else print $2}')"
-  PROJECTION="${LOW} - ${HIGH}"
+  # The projection does NOT follow the 10 t rule the totals use. A total is a
+  # measurement and reads better as a four-digit kilogram figure; a projection is an
+  # extrapolation from a daily average, and "1414 - 1686 kg" claims a precision it
+  # simply does not have. Tonnes with one decimal state the same range at the
+  # resolution the method actually supports.
+  #
+  # Below 0.1 t the tonne tier would collapse to "0.0 - 0.1", so light users fall
+  # back to whole kilograms. Both bounds always share the unit, picked on HIGH.
+  if (( $(echo "$HIGH >= 100000" | LC_ALL=C bc -l) )); then
+    PROJECTION_UNIT="tCO₂"
+    _PROJ_LO_VAL="$(echo "$LOW"  | LC_ALL=C awk '{printf "%.1f", $1/1000000}')"
+    _PROJ_HI_VAL="$(echo "$HIGH" | LC_ALL=C awk '{printf "%.1f", $1/1000000}')"
+  else
+    PROJECTION_UNIT="kgCO₂"
+    _PROJ_LO_VAL="$(echo "$LOW"  | LC_ALL=C awk '{printf "%.0f", $1/1000}')"
+    _PROJ_HI_VAL="$(echo "$HIGH" | LC_ALL=C awk '{printf "%.0f", $1/1000}')"
+  fi
+  PROJECTION="${_PROJ_LO_VAL} - ${_PROJ_HI_VAL}"
 else
   PROJECTION="0"
+  PROJECTION_UNIT="kgCO₂"
 fi
 
 # Format model
@@ -283,6 +302,7 @@ inject_common() {
     -e "s|{{TOP_MODEL}}|${TOP_MODEL_DISPLAY}|g" \
     -e "s|{{TOTAL_TOKENS}}|${TOTAL_TOKENS}|g" \
     -e "s|{{PROJECTION}}|${PROJECTION}|g" \
+  -e "s|{{PROJECTION_UNIT}}|${PROJECTION_UNIT}|g" \
     -e "s|{{P1_NAME}}|${P_NAME[0]}|g" \
     -e "s|{{P1_CO2}}|${P_CO2[0]}|g" \
     -e "s|{{P1_SESSIONS}}|${P_SESSIONS[0]}|g" \

--- a/templates/report-summary-en.html
+++ b/templates/report-summary-en.html
@@ -312,7 +312,7 @@
         </div>
         <div class="metric">
           <div class="metric-val" style="font-size: 20px">
-            ~{{PROJECTION}} tCO₂/yr
+            ~{{PROJECTION}} {{PROJECTION_UNIT}}/yr
           </div>
           <div class="metric-label">yearly projection</div>
         </div>

--- a/templates/report-summary.html
+++ b/templates/report-summary.html
@@ -312,7 +312,7 @@
         </div>
         <div class="metric">
           <div class="metric-val" style="font-size: 20px">
-            ~{{PROJECTION}} tCO₂/an
+            ~{{PROJECTION}} {{PROJECTION_UNIT}}/an
           </div>
           <div class="metric-label">projection annuelle</div>
         </div>

--- a/tests/run-badge-tests.sh
+++ b/tests/run-badge-tests.sh
@@ -76,10 +76,18 @@ check "kg tier: URL" "https://img.shields.io/badge/claude--carbon-12.4%20kg%20CO
 
 # ---------------------------------------------------------------- 3. tonne tier
 
-DB="${TMPROOT}/tonne.db"
+# The tonne tier starts at 10 t. A one-tonne total, which is what a year of heavy
+# personal use looks like, stays in kilograms so the badge keeps a figure with
+# some weight to it rather than collapsing to "1.2 t".
+DB="${TMPROOT}/below-tonne-tier.db"
 make_db "$DB" 1234000
 OUT="$(run_badge "$DB" en_US)"
-check "tonne tier: URL" "https://img.shields.io/badge/claude--carbon-1.2%20t%20CO2e-2f6f4f" "$(url_of "$OUT")"
+check "below tonne tier: still kg" "https://img.shields.io/badge/claude--carbon-1234.0%20kg%20CO2e-2f6f4f" "$(url_of "$OUT")"
+
+DB="${TMPROOT}/tonne.db"
+make_db "$DB" 12340000
+OUT="$(run_badge "$DB" en_US)"
+check "tonne tier: URL" "https://img.shields.io/badge/claude--carbon-12.3%20t%20CO2e-2f6f4f" "$(url_of "$OUT")"
 
 # ---------------------------------------------------------------- 4. FR comma, escaped
 
@@ -116,10 +124,17 @@ check "missing DB: message"    "Error: carbon.db not found. Run setup.sh first."
 
 # shellcheck source=../scripts/format-lib.sh
 . "${REPO_DIR}/scripts/format-lib.sh"
-check "format_co2 999"     "999 g"  "$(format_co2 999)"
-check "format_co2 1000"    "1.0 kg" "$(format_co2 1000)"
-check "format_co2 999999"  "1000.0 kg" "$(format_co2 999999)"
-check "format_co2 1000000" "1.0 t"  "$(format_co2 1000000)"
+check "format_co2 999"      "999 g"      "$(format_co2 999)"
+check "format_co2 1000"     "1.0 kg"     "$(format_co2 1000)"
+check "format_co2 999999"   "1000.0 kg"  "$(format_co2 999999)"
+# The tonne tier starts at 10 t, not 1 t: a one-tonne total reads as "1016.3 kg",
+# not "1.0 t", so the figure keeps its weight instead of collapsing to a rounding
+# artefact. These four pin the boundary from both sides.
+check "format_co2 1000000"  "1000.0 kg"  "$(format_co2 1000000)"
+check "format_co2 1016300"  "1016.3 kg"  "$(format_co2 1016300)"
+check "format_co2 9999999"  "10000.0 kg" "$(format_co2 9999999)"
+check "format_co2 10000000" "10.0 t"     "$(format_co2 10000000)"
+check "format_co2 25400000" "25.4 t"     "$(format_co2 25400000)"
 
 # ----------------------------------------------------------------
 


### PR DESCRIPTION
## The problem

The card hero read **1.0 t of estimated CO2** for a total of 1016.5 kg.

The tonne tier started at 1 t, which means the first real milestone a heavy user crosses is also the exact point where the number shrinks to one significant digit. A year of work collapses into "1.0", which reads as a rounding artefact rather than as a quantity. The figure got smaller precisely when the footprint got big enough to matter.

## Totals: kilograms until 10 t

`format_co2` now switches to tonnes at 10 t instead of 1 t. The same total renders as **1016.5 kg**.

It is a single shared function, so the card, the badge, `/carbon-report` and `/carbon-pr` all move together. The tonne tier is left for fleet-scale numbers, where five digits of kilograms would be the harder read.

## Projections: tonnes, and deliberately not the same rule

The yearly projection does not follow the totals rule, on purpose.

A total is a measurement and carries its digits honestly. A projection extrapolates a daily average over a year, and `1414 - 1686 kgCO2/yr` claims four digits of precision the method does not have. Tonnes with one decimal state the same range at the resolution actually supported: `~1.4 - 1.7 tCO2/yr`.

Below 0.1 t the tonne tier would collapse to `0.0 - 0.1`, so light users fall back to whole kilograms. Both bounds always share a unit, picked on the high end, so a range can never straddle a tier boundary.

`{{PROJECTION_UNIT}}` is a new slot in `report-summary.html` and `report-summary-en.html`, where the unit previously sat hardcoded next to the value.

## Result

| | before | after |
|---|---|---|
| Hero | `1.0 t` | `1016.5 kg` |
| Badge | `1.0 kg CO2e` (at 1 t: `1.0 t`) | `1016.5 kg CO2e` |
| Projection | `~1.4-1.7 tCO2/yr` | `~1.4 - 1.7 tCO2/yr` (unchanged in unit, now explicit rather than hardcoded) |

## Tests

The tonne-tier badge fixture moves from 1.234 t to 12.34 t, a new case pins that 1.234 t still renders as kilograms, and `format_co2` gains boundary assertions on both sides of 10 t.

```
run-vectors          16 passed
run-install-tests    31 passed
run-badge-tests      17 passed
run-pr-tests         25 passed
```

Both cards regenerated and checked visually, FR and EN.