### PR TITLE
feat: native Windows support (#27)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -18,6 +18,6 @@
   "skills": "./skills/",
   "statusLine": {
     "type": "command",
-    "command": "${CLAUDE_PLUGIN_ROOT}/scripts/statusline.sh"
+    "command": "\"${CLAUDE_PLUGIN_ROOT}/scripts/statusline.sh\""
   }
 }

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,25 @@
+# Git for Windows clones with core.autocrlf=true by default, which would rewrite
+# every shell script to CRLF on checkout. Bash then reads the carriage return as
+# part of the shebang and of every command, and the plugin fails on Windows with
+# errors like `$'\r': command not found`. Pin the working-tree line endings for
+# everything that is executed or parsed rather than edited by hand.
+*.sh        text eol=lf
+*.bash      text eol=lf
+*.json      text eol=lf
+*.jsonl     text eol=lf
+*.md        text eol=lf
+*.html      text eol=lf
+*.yml       text eol=lf
+*.cff       text eol=lf
+bin/*.js    text eol=lf
+
+# PowerShell reads LF without complaint, and `irm | iex` fetches the normalised blob
+# from GitHub rather than a checkout, so there is nothing to gain from CRLF here.
+*.ps1       text eol=lf
+
+# Never touch binary payloads.
+*.png       binary
+*.gif       binary
+*.svg       binary
+*.xlsx      binary
+*.excalidraw binary

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,8 @@ jobs:
     name: windows (git bash)
     runs-on: windows-latest
     timeout-minutes: 15
+    # Every suite reports even when an earlier one fails: a Windows-only failure costs
+    # a full push to observe, so one round-trip should surface all of them at once.
     defaults:
       run:
         # The shell Claude Code itself spawns for hooks and the status line on
@@ -108,28 +110,35 @@ jobs:
       # cc_path's cygpath branch, which a Linux or macOS runner cannot reach, plus
       # the same drift and dependency guards.
       - name: Portability contract
+        if: always()
         run: bash tests/run-portability-tests.sh
 
       - name: Methodology golden vectors
+        if: always()
         run: bash tests/run-vectors.sh
 
       - name: Install and update wiring
+        if: always()
         run: bash tests/run-install-tests.sh
 
       - name: Badge output
+        if: always()
         run: bash tests/run-badge-tests.sh
 
       - name: carbon-pr pipeline
+        if: always()
         run: bash tests/run-pr-tests.sh
 
       # The assertions no other runner can make: a real cygpath, a native path
       # pointing at a real file, and the hook manifests spawned the way Claude Code
       # spawns them (placeholder substituted into the string, string handed to bash).
       - name: Windows end-to-end
+        if: always()
         run: bash tests/run-windows-e2e.sh
 
       # install.ps1 is the one file no POSIX machine can even parse.
       - name: install.ps1
+        if: always()
         shell: powershell
         run: .\tests\run-install-ps1-tests.ps1
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,11 @@ jobs:
       - name: Assert the cross-platform contract
         run: bash tests/run-portability-tests.sh
 
+      # Skips with exit 0 off Windows. Running it here keeps that skip path honest,
+      # so the suite can never start failing the matrix for the wrong reason.
+      - name: Windows end-to-end (expected to skip here)
+        run: bash tests/run-windows-e2e.sh
+
   windows:
     name: windows (git bash)
     runs-on: windows-latest
@@ -116,6 +121,17 @@ jobs:
 
       - name: carbon-pr pipeline
         run: bash tests/run-pr-tests.sh
+
+      # The assertions no other runner can make: a real cygpath, a native path
+      # pointing at a real file, and the hook manifests spawned the way Claude Code
+      # spawns them (placeholder substituted into the string, string handed to bash).
+      - name: Windows end-to-end
+        run: bash tests/run-windows-e2e.sh
+
+      # install.ps1 is the one file no POSIX machine can even parse.
+      - name: install.ps1
+        shell: powershell
+        run: .\tests\run-install-ps1-tests.ps1
 
   shellcheck:
     name: shellcheck

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,8 +40,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # Runs against throwaway fixture DBs via CLAUDE_CARBON_DB; sqlite3 and bc
-      # are preinstalled on ubuntu-latest.
+      # Runs against throwaway fixture DBs via CLAUDE_CARBON_DB; sqlite3 is
+      # preinstalled on ubuntu-latest.
       - name: Assert badge URL and snippet against fixture databases
         run: bash tests/run-badge-tests.sh
 
@@ -55,6 +55,66 @@ jobs:
       # Fixture transcript through the Stop hook (git_branch capture), then the
       # dry-run report against fixture DBs. No network, no gh.
       - name: Assert branch capture and the dev PR report
+        run: bash tests/run-pr-tests.sh
+
+  portability:
+    name: portability contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      # Pure string logic plus the anti-regression guards (no bc, no python3, no
+      # hardcoded /tmp, LF endings, quoted hook placeholders). No extra deps.
+      - name: Assert the cross-platform contract
+        run: bash tests/run-portability-tests.sh
+
+  windows:
+    name: windows (git bash)
+    runs-on: windows-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        # The shell Claude Code itself spawns for hooks and the status line on
+        # Windows, so the suite runs in the environment users actually get.
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
+
+      # jq and sqlite3 are the two commands Git for Windows does not ship, and the
+      # two the README asks Windows users to install. Everything else the plugin
+      # touches (bash, awk, sed, grep, date, curl, git, cygpath) comes with Git.
+      - name: Install jq and sqlite3
+        run: |
+          command -v jq      >/dev/null 2>&1 || choco install jq     --no-progress -y
+          command -v sqlite3 >/dev/null 2>&1 || choco install sqlite --no-progress -y
+
+      - name: Report the toolchain actually available
+        run: |
+          echo "uname   : $(uname -s)"
+          echo "OSTYPE  : ${OSTYPE:-unset}"
+          echo "bash    : ${BASH_VERSION}"
+          echo "jq      : $(jq --version)"
+          echo "sqlite3 : $(sqlite3 --version)"
+          echo "awk     : $(awk --version 2>/dev/null | head -1 || echo present)"
+          echo "cygpath : $(command -v cygpath || echo MISSING)"
+          echo "TMPDIR  : ${TMPDIR:-unset}"
+
+      # cc_path's cygpath branch, which a Linux or macOS runner cannot reach, plus
+      # the same drift and dependency guards.
+      - name: Portability contract
+        run: bash tests/run-portability-tests.sh
+
+      - name: Methodology golden vectors
+        run: bash tests/run-vectors.sh
+
+      - name: Install and update wiring
+        run: bash tests/run-install-tests.sh
+
+      - name: Badge output
+        run: bash tests/run-badge-tests.sh
+
+      - name: carbon-pr pipeline
         run: bash tests/run-pr-tests.sh
 
   shellcheck:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,8 +61,21 @@ network, and the macOS Keychain lookup is now guarded on the platform instead of
   exists, the drift between `install.sh`'s inline fallback and the real library, the
   absence of `bc` / `python3` / hardcoded `/tmp`, the LF pinning, the quoted
   placeholders, and the syntax of every script and every `SKILL.md` bash block.
+- `tests/run-windows-e2e.sh`: the assertions no other machine can make, skipped with
+  exit 0 off Windows. A real `cygpath` round-trip on a file whose directory contains a
+  space; the Stop hook fed a native `transcript_path` and asserted to land a row with
+  the right token breakdown, project and branch; the status line fed a native
+  `current_dir`; the hook manifests spawned the way Claude Code spawns them, with the
+  placeholder substituted into the command string and the string handed to bash from a
+  native plugin root; `settings.json` asserted free of backslashes and openable;
+  slash-command copies asserted to refresh while a user-written command survives.
+- `tests/run-install-ps1-tests.ps1`: `install.ps1` parses, finds Git Bash, refuses the
+  `System32\bash.exe` WSL launcher, honours `CLAUDE_CODE_GIT_BASH_PATH` and falls
+  through when it points nowhere, normalises a CRLF download, and propagates the
+  installer's exit code. Run against a stub served over loopback, so nothing is cloned.
 - CI gains a `windows-latest` job running the whole suite under Git Bash, which is the
-  only place the `cygpath` branch is reachable, plus a `portability` job on Ubuntu.
+  only place the `cygpath` branch is reachable, plus a `portability` job on Ubuntu that
+  also exercises the e2e suite's skip path.
 - README gains a Windows section: the three install paths, and the specifics worth
   knowing (forward slashes in `settings.json`, copied commands, no sandboxing).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,71 @@
 # Changelog
 
+## 2026-09-02
+
+### feat: native Windows support (issue #27)
+
+`npx claude-carbon` refused to run on Windows and the plugin assumed a POSIX
+machine everywhere else. It now runs on native Windows through the Git Bash that
+Claude Code itself spawns for hooks and the status line, falling back to PowerShell
+only when Git Bash is absent, which is why the plugin stays bash rather than being
+ported: it speaks the shell its host already uses.
+
+Five things were actually broken, all of them silent failures rather than errors:
+
+**Native paths.** Claude Code is a native binary, so the JSON it pipes into the Stop
+hook and the status line carries `C:\Users\me\.claude\projects\...\x.jsonl`, and
+`${CLAUDE_PLUGIN_ROOT}` expands the same way. Bash reads those backslashes as escape
+characters. A new `scripts/portable-lib.sh` converts every path crossing that boundary
+through `cygpath`, with a string rewrite as fallback, and `cc_native_path` does the
+reverse for the paths written back into `settings.json`, which Claude Code may resolve
+with Windows APIs before handing them to Git Bash. The five `SKILL.md` files carry
+their own copy of the conversion: they resolve `CLAUDE_*` variables before any library
+is reachable.
+
+**Unquoted placeholders in the hook wiring.** `plugin.json` and `hooks.json` passed
+`${CLAUDE_PLUGIN_ROOT}/scripts/x.sh` unquoted. In shell form Claude Code hands that
+string to `sh -c`, or to Git Bash on Windows, where the separators disappear. Both
+manifests now quote the placeholder, as the hooks documentation requires. This also
+fixes a plugin root containing a space on macOS and Linux.
+
+**Line endings.** Git for Windows clones with `core.autocrlf=true` by default, which
+would have rewritten every script to CRLF and made bash fail on `$'\r'`. A
+`.gitattributes` pins `*.sh` and the other parsed files to LF.
+
+**Two dependencies Git for Windows does not ship.** `bc` was used for three float
+comparisons and is now `cc_num_ge`, one awk call; `python3` generated the monthly bar
+chart and served the pages for the PNG export, and is now node, already required for
+Playwright on that path. `jq` and `sqlite3` are the whole remaining Windows
+prerequisite list. The node rewrite of the bar chart was verified by generating all
+four report pages from a real 226-session database on `main` and on this branch: the
+HTML is byte-identical.
+
+**Symlinked slash commands.** Git Bash silently degrades `ln -s` to a copy without
+Developer Mode. `configure-settings.sh` now copies on purpose and refreshes the copy
+on every update, so `/carbon-update` still reaches the commands. A file the user wrote
+themselves is left alone.
+
+Two smaller wins came out of it: the local PNG export server binds `127.0.0.1` where
+`python3 -m http.server` defaulted to `0.0.0.0` and briefly published the pages to the
+network, and the macOS Keychain lookup is now guarded on the platform instead of on a
+`security` binary that could be something else entirely.
+
+- `install.ps1`: PowerShell bootstrap that locates Git Bash (skipping the
+  `System32\bash.exe` WSL launcher), checks `jq` and `sqlite3` through Git Bash's own
+  PATH, normalises the downloaded installer's line endings, and hands over to
+  `install.sh`.
+- `bin/claude-carbon.js`: `npx claude-carbon` finds `bash.exe` instead of refusing,
+  honouring `CLAUDE_CODE_GIT_BASH_PATH` first.
+- `tests/run-portability-tests.sh`: 32 assertions covering the path conversion with
+  the platform forced, `cc_num_ge` cross-checked against `bc` itself where `bc`
+  exists, the drift between `install.sh`'s inline fallback and the real library, the
+  absence of `bc` / `python3` / hardcoded `/tmp`, the LF pinning, the quoted
+  placeholders, and the syntax of every script and every `SKILL.md` bash block.
+- CI gains a `windows-latest` job running the whole suite under Git Bash, which is the
+  only place the `cygpath` branch is reachable, plus a `portability` job on Ubuntu.
+- README gains a Windows section: the three install paths, and the specifics worth
+  knowing (forward slashes in `settings.json`, copied commands, no sandboxing).
+
 ## 2026-08-24
 
 ### fix: totals stay in kilograms until 10 t, projections stay in tonnes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,13 @@ network, and the macOS Keychain lookup is now guarded on the platform instead of
   `System32\bash.exe` WSL launcher, honours `CLAUDE_CODE_GIT_BASH_PATH` and falls
   through when it points nowhere, normalises a CRLF download, and propagates the
   installer's exit code. Run against a stub served over loopback, so nothing is cloned.
+- `configure-settings.sh` hook dedupe: under Git Bash, command substitution drops the
+  carriage return from a single-line capture but keeps the interior ones, so reading
+  several hook commands back out of `jq` yields a bare CR on every line but the last.
+  Our own hook then failed to match itself whenever another tool's hook sat after it in
+  the same event, and every install or update appended a second copy. Found by the
+  Windows runner, and only because the foreign-hook fixture happened to order them that
+  way: with ours last, the accidental case, everything looked idempotent.
 - CI gains a `windows-latest` job running the whole suite under Git Bash, which is the
   only place the `cygpath` branch is reachable, plus a `portability` job on Ubuntu that
   also exercises the e2e suite's skip path.

--- a/README.md
+++ b/README.md
@@ -12,17 +12,25 @@ Track the carbon footprint of your Claude Code sessions.
 
 **1. Install (or update):**
 
+macOS, Linux, WSL:
+
 ```bash
 curl -fsSL https://raw.githubusercontent.com/gwittebolle/claude-carbon/main/install.sh | bash
 ```
 
-Or, if you have Node.js:
+Windows (PowerShell), which needs [Git for Windows](https://git-scm.com/downloads/win) and two packages first - see [Windows](#windows):
+
+```powershell
+irm https://raw.githubusercontent.com/gwittebolle/claude-carbon/main/install.ps1 | iex
+```
+
+Or, on any platform with Node.js:
 
 ```bash
 npx claude-carbon
 ```
 
-Same command to install and to update to the latest version (both run the same installer).
+Same command to install and to update to the latest version (all three run the same installer).
 
 **2. Restart Claude Code.** Your CO2 appears in the status line:
 
@@ -309,9 +317,9 @@ curl -fsSL https://raw.githubusercontent.com/gwittebolle/claude-carbon/main/inst
 - `sqlite3` - local database
 - `git` - branch detection in status line (optional)
 - `curl` - 5h quota usage via Anthropic's `/api/oauth/usage` endpoint (optional, 60s cache)
-- `playwright-core` + Chromium - PNG export for `/carbon-card` (optional)
+- `node` + `playwright-core` + Chromium - PNG export for `/carbon-card` (optional)
 
-`jq` and `sqlite3` are pre-installed on macOS. On Linux: `apt install jq sqlite3`.
+`jq` and `sqlite3` are pre-installed on macOS. On Linux: `apt install jq sqlite3`. On Windows, see below.
 
 To use `/carbon-card`, install Playwright and its Chromium browser:
 
@@ -319,6 +327,59 @@ To use `/carbon-card`, install Playwright and its Chromium browser:
 npm install -g playwright-core
 npx playwright install chromium
 ```
+
+## Windows
+
+claude-carbon is bash, and stays bash on Windows. That is deliberate rather than a
+shortcut: on native Windows, Claude Code runs status line and hook commands through
+the bash that ships with [Git for Windows](https://git-scm.com/downloads/win), falling
+back to PowerShell only when Git Bash is absent
+([status line docs](https://code.claude.com/docs/en/statusline#windows-configuration),
+[hooks docs](https://code.claude.com/docs/en/hooks)). The plugin speaks the shell its
+host already spawns.
+
+**Native Windows.** Install Git for Windows, plus the two commands it does not ship:
+
+```powershell
+winget install Git.Git
+winget install jqlang.jq
+winget install SQLite.SQLite
+```
+
+Open a new terminal so `PATH` picks them up, then:
+
+```powershell
+irm https://raw.githubusercontent.com/gwittebolle/claude-carbon/main/install.ps1 | iex
+```
+
+Everything else the plugin needs - `bash`, `awk`, `sed`, `grep`, `date`, `curl`,
+`git`, `cygpath` - comes with Git for Windows.
+
+**WSL 2.** Nothing special: run the `curl | bash` installer inside your distribution.
+Claude Code, its transcripts and claude-carbon all live on the Linux side. This is
+the path to pick if your projects are already in WSL. VS Code reaches it through the
+Remote - WSL extension.
+
+**Marketplace install.** `/plugin install claude-carbon@claude-carbon` behaves the
+same as on macOS, once Git for Windows, `jq` and `sqlite3` are present.
+
+### Windows specifics
+
+- **Git Bash is required.** Without it Claude Code routes commands to PowerShell,
+  which cannot run a `.sh` file. `claude doctor` tells you which shell it picked. If
+  Git is installed somewhere unusual, point Claude Code at it in `settings.json`:
+  `{"env": {"CLAUDE_CODE_GIT_BASH_PATH": "C:\\Program Files\\Git\\bin\\bash.exe"}}`.
+- **Paths in `settings.json` use forward slashes** (`C:/Users/you/code/claude-carbon/...`).
+  Git Bash eats unquoted backslashes, and the command then fails with no visible error.
+  The installer writes them correctly; only hand-edits need the care.
+- **Slash commands are copied, not symlinked.** Git Bash cannot create a real symlink
+  without Developer Mode, so `/carbon-report` and friends are copied into
+  `~/.claude/commands/` and refreshed on every update.
+- **Sandboxing is not available** on native Windows (a Claude Code limitation, not
+  this plugin's). Use WSL 2 if you need it.
+- **`/carbon-card` additionally needs Node.js**: `winget install OpenJS.NodeJS`.
+
+CI runs the full test suite on `windows-latest` under Git Bash, alongside Ubuntu.
 
 ## Reduce your footprint
 

--- a/README.md
+++ b/README.md
@@ -379,7 +379,10 @@ same as on macOS, once Git for Windows, `jq` and `sqlite3` are present.
   this plugin's). Use WSL 2 if you need it.
 - **`/carbon-card` additionally needs Node.js**: `winget install OpenJS.NodeJS`.
 
-CI runs the full test suite on `windows-latest` under Git Bash, alongside Ubuntu.
+CI runs the full test suite on `windows-latest` under Git Bash, alongside Ubuntu,
+plus two Windows-only suites: `tests/run-windows-e2e.sh` (native paths through the Stop
+hook and the status line, hook manifests spawned the way Claude Code spawns them) and
+`tests/run-install-ps1-tests.ps1`.
 
 ## Reduce your footprint
 

--- a/bin/claude-carbon.js
+++ b/bin/claude-carbon.js
@@ -6,10 +6,44 @@
 "use strict";
 
 const { spawnSync } = require("node:child_process");
-const { mkdtempSync, writeFileSync } = require("node:fs");
+const { existsSync, mkdtempSync, writeFileSync } = require("node:fs");
 const { tmpdir } = require("node:os");
 const { join } = require("node:path");
 const pkg = require("../package.json");
+
+// The installer, the hooks and the status line are all bash. On macOS and Linux
+// that is simply "bash"; on Windows it is the bash.exe that ships with Git for
+// Windows, which is also the shell Claude Code itself spawns for hooks and the
+// status line. Returns null when nothing usable is found.
+function findBash() {
+  if (process.platform !== "win32") return "bash";
+
+  const candidates = [
+    // Same variable Claude Code reads, so a user who already pointed Claude Code
+    // at a non-default Git install does not have to say it twice.
+    process.env.CLAUDE_CODE_GIT_BASH_PATH,
+    join(process.env.ProgramFiles || "C:\\Program Files", "Git", "bin", "bash.exe"),
+    join(process.env["ProgramFiles(x86)"] || "C:\\Program Files (x86)", "Git", "bin", "bash.exe"),
+    join(process.env.LOCALAPPDATA || "", "Programs", "Git", "bin", "bash.exe"),
+  ].filter(Boolean);
+
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) return candidate;
+  }
+
+  // Last resort: ask PATH. C:\Windows\System32\bash.exe is excluded on purpose —
+  // that one is the WSL launcher, and running the installer through it would set
+  // claude-carbon up inside the Linux distribution instead of on Windows.
+  const where = spawnSync("where.exe", ["bash"], { encoding: "utf8" });
+  if (where.status === 0 && where.stdout) {
+    for (const line of where.stdout.split(/\r?\n/)) {
+      const path = line.trim();
+      if (path && !/\\System32\\/i.test(path) && existsSync(path)) return path;
+    }
+  }
+
+  return null;
+}
 
 const INSTALL_URL =
   process.env.CLAUDE_CARBON_INSTALL_URL ||
@@ -46,9 +80,14 @@ if (arg !== undefined && arg !== "--dry-run") {
 }
 
 async function main() {
-  if (process.platform === "win32") {
+  const bash = findBash();
+  if (!bash) {
     console.error(
-      "claude-carbon needs bash (macOS or Linux); Windows is not supported yet.",
+      "claude-carbon runs on bash. On Windows that means Git for Windows, which\n" +
+        "Claude Code also uses for its own Bash tool.\n\n" +
+        "  Install it:  winget install Git.Git\n" +
+        "  Or, if it is already installed somewhere unusual, point at it:\n" +
+        '    set CLAUDE_CODE_GIT_BASH_PATH="C:\\Program Files\\Git\\bin\\bash.exe"',
     );
     process.exit(1);
   }
@@ -73,9 +112,9 @@ async function main() {
     process.exit(0);
   }
 
-  const { status, error } = spawnSync("bash", [file], { stdio: "inherit" });
+  const { status, error } = spawnSync(bash, [file], { stdio: "inherit" });
   if (error) {
-    console.error(`Could not run bash: ${error.message}`);
+    console.error(`Could not run ${bash}: ${error.message}`);
     process.exit(1);
   }
   process.exit(status ?? 1);

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/persist-session.sh"
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/scripts/persist-session.sh\""
           }
         ]
       }
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/safety-rescan.sh"
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/scripts/safety-rescan.sh\""
           }
         ]
       }

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,113 @@
+#Requires -Version 5.1
+<#
+    install.ps1 - Windows bootstrap for claude-carbon.
+
+    Usage (PowerShell):
+      irm https://raw.githubusercontent.com/gwittebolle/claude-carbon/main/install.ps1 | iex
+
+    claude-carbon itself is bash, and stays bash on Windows: Claude Code spawns the
+    bash.exe from Git for Windows to run hooks and the status line, so the plugin
+    has to speak the same shell its host does. This script only does the part
+    PowerShell is needed for - finding that bash.exe, checking the two commands Git
+    for Windows does not ship - and then hands over to install.sh.
+#>
+
+$ErrorActionPreference = 'Stop'
+
+$InstallUrl = if ($env:CLAUDE_CARBON_INSTALL_URL) {
+    $env:CLAUDE_CARBON_INSTALL_URL
+} else {
+    'https://raw.githubusercontent.com/gwittebolle/claude-carbon/main/install.sh'
+}
+
+Write-Host ''
+Write-Host '  claude-carbon installer'
+Write-Host '  Track the carbon footprint of your Claude Code sessions.'
+Write-Host ''
+
+# ── 1. Locate Git Bash ───────────────────────────────────────────────────────
+function Find-GitBash {
+    $candidates = @(
+        # The same variable Claude Code reads, so a non-default Git install only
+        # has to be declared once.
+        $env:CLAUDE_CODE_GIT_BASH_PATH,
+        (Join-Path $env:ProgramFiles 'Git\bin\bash.exe'),
+        (Join-Path ${env:ProgramFiles(x86)} 'Git\bin\bash.exe'),
+        (Join-Path $env:LOCALAPPDATA 'Programs\Git\bin\bash.exe')
+    ) | Where-Object { $_ }
+
+    foreach ($candidate in $candidates) {
+        if (Test-Path -LiteralPath $candidate -PathType Leaf) { return $candidate }
+    }
+
+    # PATH as a last resort. C:\Windows\System32\bash.exe is skipped deliberately:
+    # that one launches WSL, and installing through it would put claude-carbon
+    # inside the Linux distribution rather than on Windows.
+    Get-Command bash.exe -All -ErrorAction SilentlyContinue |
+        Where-Object { $_.Source -and $_.Source -notmatch '\\System32\\' } |
+        Select-Object -First 1 -ExpandProperty Source
+}
+
+$bash = Find-GitBash
+if (-not $bash) {
+    Write-Host 'ERROR: Git for Windows was not found.' -ForegroundColor Red
+    Write-Host '  claude-carbon runs on its bash, and so does Claude Code''s own Bash tool.'
+    Write-Host ''
+    Write-Host '  Install it:  winget install Git.Git'
+    Write-Host '  Already installed elsewhere? Point at it and rerun:'
+    Write-Host '    $env:CLAUDE_CODE_GIT_BASH_PATH = "D:\Git\bin\bash.exe"'
+    exit 1
+}
+Write-Host "  Git Bash: $bash"
+
+# ── 2. Check the two commands Git for Windows does not ship ──────────────────
+# jq and sqlite3 are the whole Windows prerequisite list: bash, awk, sed, grep,
+# date, curl and git all come with Git for Windows.
+$missing = @()
+foreach ($dep in @(
+    @{ Name = 'jq';      Package = 'jqlang.jq' },
+    @{ Name = 'sqlite3'; Package = 'SQLite.SQLite' }
+)) {
+    # Resolved through Git Bash, not PowerShell: that is the PATH the plugin will
+    # actually run under, and it includes the Git usr\bin directory.
+    & $bash -lc "command -v $($dep.Name)" *> $null
+    if ($LASTEXITCODE -ne 0) { $missing += $dep } else { Write-Host "  $($dep.Name): OK" }
+}
+
+if ($missing.Count -gt 0) {
+    Write-Host ''
+    Write-Host 'ERROR: missing dependencies.' -ForegroundColor Red
+    foreach ($dep in $missing) {
+        Write-Host "  $($dep.Name) - install with:  winget install $($dep.Package)"
+    }
+    Write-Host ''
+    Write-Host '  Then open a new terminal (so PATH is refreshed) and rerun this installer.'
+    exit 1
+}
+
+# ── 3. Hand over to install.sh ───────────────────────────────────────────────
+Write-Host ''
+Write-Host 'Running the installer...'
+
+$tempDir = Join-Path ([System.IO.Path]::GetTempPath()) ("claude-carbon-" + [System.Guid]::NewGuid().ToString('N').Substring(0, 8))
+New-Item -ItemType Directory -Path $tempDir -Force | Out-Null
+$scriptPath = Join-Path $tempDir 'install.sh'
+
+try {
+    Invoke-WebRequest -Uri $InstallUrl -OutFile $scriptPath -UseBasicParsing
+} catch {
+    Write-Host "ERROR: could not download the installer from $InstallUrl" -ForegroundColor Red
+    Write-Host "  $($_.Exception.Message)"
+    exit 1
+}
+
+# The download arrives with whatever line endings the server sent. bash treats a
+# trailing carriage return as part of every command, so normalise before running.
+$content = [System.IO.File]::ReadAllText($scriptPath)
+[System.IO.File]::WriteAllText($scriptPath, $content.Replace("`r`n", "`n"))
+
+& $bash $scriptPath
+$code = $LASTEXITCODE
+
+Remove-Item -LiteralPath $tempDir -Recurse -Force -ErrorAction SilentlyContinue
+exit $code

--- a/install.sh
+++ b/install.sh
@@ -4,10 +4,64 @@ set -euo pipefail
 # install.sh — One-line installer for claude-carbon.
 # Usage: curl -fsSL https://raw.githubusercontent.com/gwittebolle/claude-carbon/main/install.sh | bash
 
-INSTALL_DIR="${CLAUDE_CARBON_DIR:-$HOME/code/claude-carbon}"
+# `curl … | bash` leaves BASH_SOURCE unset, which `set -u` would treat as fatal.
+SCRIPT_SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" 2>/dev/null && pwd || echo "")"
+# The installer is normally curl-piped into bash, with no clone on disk yet, so it
+# carries a minimal copy of the two helpers it needs before the dependency check:
+# the platform probe behind the install hints, and the Windows path conversion.
+# tests/run-portability-tests.sh asserts this fallback agrees with the real
+# scripts/portable-lib.sh on every input, so the two cannot drift apart.
+if [ -n "$SCRIPT_SELF_DIR" ] && [ -f "${SCRIPT_SELF_DIR}/scripts/portable-lib.sh" ]; then
+  # shellcheck source=scripts/portable-lib.sh
+  . "${SCRIPT_SELF_DIR}/scripts/portable-lib.sh"
+else
+  # >>> portable-lib fallback
+  case "${OSTYPE:-}" in
+    darwin*)       CC_OS="darwin" ;;
+    msys*|cygwin*) CC_OS="windows" ;;
+    *)             CC_OS="linux" ;;
+  esac
+  cc_install_hint() {
+    case "$CC_OS" in
+      darwin) printf 'brew install %s' "$1" ;;
+      windows)
+        case "$1" in
+          jq)      printf 'winget install jqlang.jq' ;;
+          sqlite3) printf 'winget install SQLite.SQLite' ;;
+          git)     printf 'winget install Git.Git' ;;
+          node)    printf 'winget install OpenJS.NodeJS' ;;
+          *)       printf 'winget install %s' "$1" ;;
+        esac
+        ;;
+      *) printf 'apt install %s' "$1" ;;
+    esac
+  }
+  cc_path() {
+    local p="${1:-}"
+    [ -n "$p" ] || return 0
+    if [ "$CC_OS" != "windows" ]; then printf '%s' "$p"; return 0; fi
+    case "$p" in
+      [A-Za-z]:[\\/]*|*\\*)
+        if command -v cygpath >/dev/null 2>&1; then
+          cygpath -u "$p" 2>/dev/null || printf '%s' "$p"
+        else
+          p="${p//\\//}"
+          case "$p" in
+            [A-Za-z]:/*) printf '/%s%s' "$(printf '%s' "${p%%:*}" | tr 'A-Z' 'a-z')" "${p#*:}" ;;
+            *) printf '%s' "$p" ;;
+          esac
+        fi
+        ;;
+      *) printf '%s' "$p" ;;
+    esac
+  }
+  # <<< portable-lib fallback
+fi
+
+INSTALL_DIR="$(cc_path "${CLAUDE_CARBON_DIR:-$HOME/code/claude-carbon}")"
 # Honour Claude Code's own CLAUDE_CONFIG_DIR so a second environment
 # (e.g. CLAUDE_CONFIG_DIR=~/.claude-work claude) installs into its own dir.
-CONFIG_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+CONFIG_DIR="$(cc_path "${CLAUDE_CONFIG_DIR:-$HOME/.claude}")"
 
 echo ""
 echo "  claude-carbon installer"
@@ -18,11 +72,8 @@ echo ""
 for cmd in jq sqlite3 git; do
   if ! command -v "$cmd" &>/dev/null; then
     echo "ERROR: $cmd is not installed." >&2
-    if [[ "$(uname)" == "Darwin" ]]; then
-      echo "  Install with: brew install $cmd" >&2
-    else
-      echo "  Install with: apt install $cmd" >&2
-    fi
+    echo "  Install with: $(cc_install_hint "$cmd")" >&2
+    [ "$CC_OS" = "windows" ] && echo "  Then reopen this shell so PATH picks it up." >&2
     exit 1
   fi
 done

--- a/scripts/backfill.sh
+++ b/scripts/backfill.sh
@@ -11,10 +11,12 @@ set -euo pipefail
 # what the two billing rates apply to; see data/prices.json.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/portable-lib.sh
+. "${SCRIPT_DIR}/portable-lib.sh"
 FACTORS_FILE="${SCRIPT_DIR}/../data/factors.json"
 PRICES_FILE="${SCRIPT_DIR}/../data/prices.json"
-CONFIG_DIR="${CLAUDE_CONFIG_DIR:-${HOME}/.claude}"
-DB_PATH="${CLAUDE_CARBON_DB:-${CONFIG_DIR}/claude-carbon/carbon.db}"
+CONFIG_DIR="$(cc_path "${CLAUDE_CONFIG_DIR:-${HOME}/.claude}")"
+DB_PATH="$(cc_path "${CLAUDE_CARBON_DB:-${CONFIG_DIR}/claude-carbon/carbon.db}")"
 
 # Rows written by this version of the methodology (raw-token columns populated).
 METHODOLOGY_VERSION=2

--- a/scripts/check-update.sh
+++ b/scripts/check-update.sh
@@ -5,8 +5,10 @@
 # hook (safety-rescan.sh), at most once/day. Swallows every error; safe to kill anytime.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/portable-lib.sh
+. "${SCRIPT_DIR}/portable-lib.sh"
 REPO_DIR="$(dirname "$SCRIPT_DIR")"
-STATE_DIR="${CLAUDE_CONFIG_DIR:-${HOME}/.claude}/claude-carbon"
+STATE_DIR="$(cc_path "${CLAUDE_CONFIG_DIR:-${HOME}/.claude}")/claude-carbon"
 OUT="${STATE_DIR}/update-check.json"
 
 # Opt-out (mirrors npm/gh NO_UPDATE_NOTIFIER convention)

--- a/scripts/configure-settings.sh
+++ b/scripts/configure-settings.sh
@@ -10,7 +10,9 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 INSTALL_DIR="$(dirname "$SCRIPT_DIR")"
-CONFIG_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+# shellcheck source=scripts/portable-lib.sh
+. "${SCRIPT_DIR}/portable-lib.sh"
+CONFIG_DIR="$(cc_path "${CLAUDE_CONFIG_DIR:-$HOME/.claude}")"
 SETTINGS_FILE="${CONFIG_DIR}/settings.json"
 
 # Marketplace installs declare their hooks in hooks/hooks.json (see plugin.json); writing them
@@ -24,9 +26,14 @@ fi
 
 mkdir -p "$CONFIG_DIR"
 
-STATUSLINE_CMD="${INSTALL_DIR}/scripts/statusline.sh"
-STOP_CMD="${INSTALL_DIR}/scripts/persist-session.sh"
-SESSIONSTART_CMD="${INSTALL_DIR}/scripts/safety-rescan.sh"
+# Claude Code is a native binary on Windows and may resolve these paths itself
+# before handing them to Git Bash, so settings.json gets the "mixed" spelling
+# ("C:/Users/me/…"): valid for the Windows side, and openable by bash as written.
+# Identity on macOS and Linux, so nothing changes there.
+CMD_DIR="$(cc_native_path "$INSTALL_DIR")"
+STATUSLINE_CMD="${CMD_DIR}/scripts/statusline.sh"
+STOP_CMD="${CMD_DIR}/scripts/persist-session.sh"
+SESSIONSTART_CMD="${CMD_DIR}/scripts/safety-rescan.sh"
 
 # Resolve a hook command to a comparable form. The same script reaches settings.json spelled
 # several ways: the README's manual block uses `~/code/claude-carbon/...`, this script writes
@@ -129,15 +136,33 @@ else
   echo "  Created $SETTINGS_FILE"
 fi
 
-# /carbon-* slash commands, symlinked so they follow the clone on update.
+# /carbon-* slash commands. Symlinked so they follow the clone on update — except
+# on Windows, where Git Bash cannot create a real symlink without Developer Mode
+# and silently makes a copy instead. There we copy on purpose, and refresh the
+# copy on every run so an update still reaches the commands.
 COMMANDS_DIR="${CONFIG_DIR}/commands"
 mkdir -p "$COMMANDS_DIR"
 for SKILL_NAME in carbon-report carbon-card carbon-update carbon-badge carbon-pr; do
+  SKILL_SRC="${INSTALL_DIR}/skills/${SKILL_NAME}/SKILL.md"
   SKILL_LNK="${COMMANDS_DIR}/${SKILL_NAME}.md"
-  if [ -L "$SKILL_LNK" ] || [ -f "$SKILL_LNK" ]; then
+  if [ -L "$SKILL_LNK" ]; then
     echo "  /${SKILL_NAME}: already installed (skipped)"
+  elif [ -f "$SKILL_LNK" ]; then
+    # A plain file where a symlink was expected: either a Windows copy of ours,
+    # which must be refreshed, or a command the user wrote, which must not be
+    # touched. Ours always names the project; a hand-written one would not.
+    if cc_is_windows && grep -q "claude-carbon" "$SKILL_LNK" 2>/dev/null; then
+      if cmp -s "$SKILL_SRC" "$SKILL_LNK"; then
+        echo "  /${SKILL_NAME}: already installed (skipped)"
+      else
+        cp -f "$SKILL_SRC" "$SKILL_LNK"
+        echo "  /${SKILL_NAME}: refreshed"
+      fi
+    else
+      echo "  /${SKILL_NAME}: already installed (skipped)"
+    fi
   else
-    ln -s "${INSTALL_DIR}/skills/${SKILL_NAME}/SKILL.md" "$SKILL_LNK"
+    cc_link_or_copy "$SKILL_SRC" "$SKILL_LNK"
     echo "  /${SKILL_NAME}: installed"
   fi
 done

--- a/scripts/configure-settings.sh
+++ b/scripts/configure-settings.sh
@@ -42,6 +42,12 @@ SESSIONSTART_CMD="${CMD_DIR}/scripts/safety-rescan.sh"
 # Commands whose directory does not exist (a third-party hook) are left as written.
 normalize_cmd() {
   local c="$1" dir base
+  # Strip a trailing carriage return. Under Git Bash, command substitution drops the
+  # CR from a single-line capture but keeps the interior ones, so reading N commands
+  # back out of jq yields a bare CR on every line but the last. Without this, our own
+  # hook fails to match itself whenever another tool's hook sits after it in the same
+  # event, and every install or update registers a second copy of ours.
+  c="${c%$'\r'}"
   c="${c//\\ / }"
   # SC2088: the tilde here is data, not a path being expanded — we are matching a literal "~/"
   # prefix inside a string read from settings.json and expanding it ourselves.

--- a/scripts/equiv-lib.sh
+++ b/scripts/equiv-lib.sh
@@ -4,6 +4,9 @@
 # factors themselves live in data/factors.json ("equivalences", one set per
 # locale). Policy: METHODOLOGY.md "Locale detection".
 
+# shellcheck source=scripts/portable-lib.sh
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/portable-lib.sh"
+
 # Echoes the equivalence set for this user: "fr", "us" or "world".
 # CLAUDE_CARBON_LOCALE forces a set (accepts a set name or a locale string).
 # Must run before any `export LC_ALL=C`, which would mask the user's locale.
@@ -17,10 +20,14 @@ detect_equiv_set() {
       *) resolved="$candidate"; break ;;
     esac
   done
-  if [ -z "$resolved" ] && [ "$(uname)" = "Darwin" ]; then
-    # Hooks and GUI-launched shells often carry no LANG at all
-    resolved="$(defaults read -g AppleLocale 2>/dev/null || true)"
+  if [ -z "$resolved" ]; then
+    # Hooks and GUI-launched shells often carry no LANG at all, and no Windows
+    # shell sets one: fall back to the OS-level locale (AppleLocale on macOS,
+    # the International registry key on Windows).
+    resolved="$(cc_system_locale)"
   fi
+  # Windows and macOS spell the locale with a hyphen ("fr-FR", "en-US") where a
+  # POSIX LANG uses an underscore; the patterns below accept both spellings.
   case "$resolved" in
     # An undetected locale falls back to the French set, this tool's original
     # default: a detection failure must reproduce the pre-locale behavior, not

--- a/scripts/format-lib.sh
+++ b/scripts/format-lib.sh
@@ -4,6 +4,9 @@
 # Callers are expected to have exported LC_ALL=C already; the pipelines below
 # pin it anyway so a stray comma-decimal locale cannot corrupt the output.
 
+# shellcheck source=scripts/portable-lib.sh
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/portable-lib.sh"
+
 # Echoes "<value> <unit>" for a gram amount, unit adapting to the magnitude:
 # "432 g", "12.4 kg", "1240.0 kg", "12.4 t". One decimal above the gram tier.
 #
@@ -17,9 +20,9 @@ TONNE_TIER_GRAMS=10000000
 
 format_co2() {
   local grams="$1"
-  if (( $(echo "$grams >= ${TONNE_TIER_GRAMS}" | LC_ALL=C bc -l) )); then
+  if cc_num_ge "$grams" "$TONNE_TIER_GRAMS"; then
     echo "$(echo "$grams" | LC_ALL=C awk '{printf "%.1f", $1/1000000}') t"
-  elif (( $(echo "$grams >= 1000" | LC_ALL=C bc -l) )); then
+  elif cc_num_ge "$grams" 1000; then
     echo "$(echo "$grams" | LC_ALL=C awk '{printf "%.1f", $1/1000}') kg"
   else
     echo "$(echo "$grams" | LC_ALL=C awk '{printf "%.0f", $1}') g"

--- a/scripts/generate-badge.sh
+++ b/scripts/generate-badge.sh
@@ -7,12 +7,14 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-DB_PATH="${CLAUDE_CARBON_DB:-${CLAUDE_CONFIG_DIR:-${HOME}/.claude}/claude-carbon/carbon.db}"
+# shellcheck source=scripts/portable-lib.sh
+. "${SCRIPT_DIR}/portable-lib.sh"
+DB_PATH="$(cc_path "${CLAUDE_CARBON_DB:-${CLAUDE_CONFIG_DIR:-${HOME}/.claude}/claude-carbon/carbon.db}")"
 REPO_URL="https://github.com/gwittebolle/claude-carbon"
 BADGE_COLOR="2f6f4f"
 
 # ── Deps check ──────────────────────────────────────────────
-for cmd in sqlite3 bc; do
+for cmd in sqlite3 awk; do
   if ! command -v "$cmd" &>/dev/null; then
     echo "Error: $cmd is required but not found." >&2
     exit 1

--- a/scripts/generate-pr-report.sh
+++ b/scripts/generate-pr-report.sh
@@ -11,9 +11,11 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/portable-lib.sh
+. "${SCRIPT_DIR}/portable-lib.sh"
 PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 FACTORS_FILE="$PROJECT_DIR/data/factors.json"
-DB_PATH="${CLAUDE_CARBON_DB:-${CLAUDE_CONFIG_DIR:-${HOME}/.claude}/claude-carbon/carbon.db}"
+DB_PATH="$(cc_path "${CLAUDE_CARBON_DB:-${CLAUDE_CONFIG_DIR:-${HOME}/.claude}/claude-carbon/carbon.db}")"
 REPO_URL="https://github.com/gwittebolle/claude-carbon"
 MARKER="<!-- claude-carbon-dev-report -->"
 
@@ -28,7 +30,7 @@ while [ $# -gt 0 ]; do
 done
 
 # ── Deps check ──────────────────────────────────────────────
-for cmd in sqlite3 jq bc git; do
+for cmd in sqlite3 jq awk git; do
   if ! command -v "$cmd" &>/dev/null; then
     echo "Error: $cmd is required but not found." >&2
     exit 1

--- a/scripts/generate-report.sh
+++ b/scripts/generate-report.sh
@@ -6,10 +6,14 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/portable-lib.sh
+. "${SCRIPT_DIR}/portable-lib.sh"
 PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 TEMPLATE_DIR="$PROJECT_DIR/templates"
 EXPORT_DIR="$PROJECT_DIR/exports"
-DB_PATH="${CLAUDE_CARBON_DB:-${CLAUDE_CONFIG_DIR:-${HOME}/.claude}/claude-carbon/carbon.db}"
+DB_PATH="$(cc_path "${CLAUDE_CARBON_DB:-${CLAUDE_CONFIG_DIR:-${HOME}/.claude}/claude-carbon/carbon.db}")"
+# One scratch dir for the temp pages and the logo the local server serves.
+CC_TMP="$(cc_tmpdir)"
 TODAY="$(date +%Y-%m-%d)"
 YEAR="$(date +%Y)"
 
@@ -228,7 +232,7 @@ if [ "$DAYS_ELAPSED" -gt 0 ]; then
   #
   # Below 0.1 t the tonne tier would collapse to "0.0 - 0.1", so light users fall
   # back to whole kilograms. Both bounds always share the unit, picked on HIGH.
-  if (( $(echo "$HIGH >= 100000" | LC_ALL=C bc -l) )); then
+  if cc_num_ge "$HIGH" 100000; then
     PROJECTION_UNIT="tCO₂"
     _PROJ_LO_VAL="$(echo "$LOW"  | LC_ALL=C awk '{printf "%.1f", $1/1000000}')"
     _PROJ_HI_VAL="$(echo "$HIGH" | LC_ALL=C awk '{printf "%.1f", $1/1000000}')"
@@ -326,8 +330,8 @@ SINCE_LABEL="$SINCE_LABEL_FR"
 EQUIV_KM="$EQUIV_KM_FR"
 EQUIV_UNIT="km"
 EQUIV_SRC="$EQUIV_TAG_FR"
-_t=$(mktemp /tmp/claude-carbon-summary-fr-XXXXXX); TMP_SUMMARY_FR="${_t}.html"; mv "$_t" "$TMP_SUMMARY_FR"
-_t=$(mktemp /tmp/claude-carbon-detailed-fr-XXXXXX); TMP_DETAILED_FR="${_t}.html"; mv "$_t" "$TMP_DETAILED_FR"
+_t=$(mktemp "${CC_TMP}/claude-carbon-summary-fr-XXXXXX"); TMP_SUMMARY_FR="${_t}.html"; mv "$_t" "$TMP_SUMMARY_FR"
+_t=$(mktemp "${CC_TMP}/claude-carbon-detailed-fr-XXXXXX"); TMP_DETAILED_FR="${_t}.html"; mv "$_t" "$TMP_DETAILED_FR"
 inject_common "$TEMPLATE_DIR/report-summary.html" "$TMP_SUMMARY_FR"
 inject_common "$TEMPLATE_DIR/report-detailed.html" "$TMP_DETAILED_FR"
 
@@ -336,81 +340,67 @@ SINCE_LABEL="$SINCE_LABEL_EN"
 EQUIV_KM="$EQUIV_KM_EN"
 EQUIV_UNIT="$EQUIV_UNIT_EN"
 EQUIV_SRC="$EQUIV_TAG_EN"
-_t=$(mktemp /tmp/claude-carbon-summary-en-XXXXXX); TMP_SUMMARY_EN="${_t}.html"; mv "$_t" "$TMP_SUMMARY_EN"
-_t=$(mktemp /tmp/claude-carbon-detailed-en-XXXXXX); TMP_DETAILED_EN="${_t}.html"; mv "$_t" "$TMP_DETAILED_EN"
+_t=$(mktemp "${CC_TMP}/claude-carbon-summary-en-XXXXXX"); TMP_SUMMARY_EN="${_t}.html"; mv "$_t" "$TMP_SUMMARY_EN"
+_t=$(mktemp "${CC_TMP}/claude-carbon-detailed-en-XXXXXX"); TMP_DETAILED_EN="${_t}.html"; mv "$_t" "$TMP_DETAILED_EN"
 inject_common "$TEMPLATE_DIR/report-summary-en.html" "$TMP_SUMMARY_EN"
 inject_common "$TEMPLATE_DIR/report-detailed-en.html" "$TMP_DETAILED_EN"
 
 # Inject monthly bars into all summary files
 TMP_SUMMARY="$TMP_SUMMARY_FR"
 
-# Inject monthly bars via python (bash/sed can't handle % in style attrs)
-_t=$(mktemp /tmp/claude-carbon-monthly-XXXXXX); TMP_MONTHLY="${_t}.txt"; mv "$_t" "$TMP_MONTHLY"
+# Inject monthly bars via node (bash/sed can't handle % in style attrs). node is
+# already required below for the Playwright lookup, so this costs no new dependency
+# and it drops python3, which a stock Windows does not ship.
+_t=$(mktemp "${CC_TMP}/claude-carbon-monthly-XXXXXX"); TMP_MONTHLY="${_t}.txt"; mv "$_t" "$TMP_MONTHLY"
 echo "$MONTHLY_DATA" > "$TMP_MONTHLY"
 
 export TMP_SUMMARY TMP_SUMMARY_EN TMP_MONTHLY
-python3 << 'PYEOF'
-import sys, os
+node << 'NODEEOF'
+const fs = require("fs");
 
-months_fr = ["Jan", "Fév", "Mar", "Avr", "Mai", "Jun", "Jul", "Aoû", "Sep", "Oct", "Nov", "Déc"]
-summary_file = os.environ["TMP_SUMMARY"]
-summary_file_en = os.environ["TMP_SUMMARY_EN"]
-monthly_file = os.environ["TMP_MONTHLY"]
+const MONTHS_FR = ["Jan", "Fév", "Mar", "Avr", "Mai", "Jun", "Jul", "Aoû", "Sep", "Oct", "Nov", "Déc"];
+const MONTHS_EN = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
 
-# Parse monthly data
-rows = []
-with open(monthly_file) as f:
-    for line in f:
-        line = line.strip()
-        if not line or "|" not in line:
-            continue
-        month_key, co2_str = line.split("|", 1)
-        co2 = float(co2_str)
-        month_num = int(month_key.split("-")[1])
-        label = months_fr[month_num - 1]
-        if co2 >= 1000:
-            display = f"{co2/1000:.1f} kg"
-        else:
-            display = f"{co2:.0f} g"
-        rows.append((label, co2, display))
+const summaryFr = process.env.TMP_SUMMARY || "";
+const summaryEn = process.env.TMP_SUMMARY_EN || "";
+const monthlyFile = process.env.TMP_MONTHLY || "";
 
-# Calculate percentages
-max_co2 = max(r[1] for r in rows) if rows else 1
-bars_html = ""
-for label, co2, display in rows:
-    pct = int(round(co2 / max_co2 * 100))
-    bars_html += (
-        f'<div class="bar-row">'
-        f'<span class="bar-label">{label}</span>'
-        f'<div class="bar-track"><div class="bar-fill" style="width: {pct}%"></div></div>'
-        f'<span class="bar-value">{display}</span>'
-        f'</div>\n'
-    )
+const rows = [];
+for (const line of fs.readFileSync(monthlyFile, "utf8").split("\n")) {
+  const trimmed = line.trim();
+  const sep = trimmed.indexOf("|");
+  if (!trimmed || sep === -1) continue;
+  rows.push({
+    monthIndex: parseInt(trimmed.slice(0, sep).split("-")[1], 10) - 1,
+    co2: parseFloat(trimmed.slice(sep + 1)),
+  });
+}
 
-# Inject into all summary files
-for sf in [summary_file, summary_file_en]:
-    if sf and os.path.exists(sf):
-        with open(sf) as f:
-            content = f.read()
-        content = content.replace("{{MONTHLY_BARS}}", bars_html)
-        with open(sf, "w") as f:
-            f.write(content)
-PYEOF
+const maxCo2 = rows.length ? Math.max(...rows.map((r) => r.co2)) : 1;
 
-export TMP_SUMMARY_EN
-python3 -c "
-import os
-sf = os.environ.get('TMP_SUMMARY_EN', '')
-if sf and os.path.exists(sf):
-    months_en = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
-    months_fr = ['Jan', 'Fév', 'Mar', 'Avr', 'Mai', 'Jun', 'Jul', 'Aoû', 'Sep', 'Oct', 'Nov', 'Déc']
-    with open(sf) as f:
-        c = f.read()
-    for fr, en in zip(months_fr, months_en):
-        c = c.replace(f'>{fr}<', f'>{en}<')
-    with open(sf, 'w') as f:
-        f.write(c)
-"
+// Each language gets its own bars, rather than building the French ones and
+// translating the finished page afterwards: a blind ">Mai<" → ">May<" pass over
+// the English file would also rewrite any other three-letter match it found.
+const barsFor = (months) =>
+  rows
+    .map((r) => {
+      const display = r.co2 >= 1000 ? (r.co2 / 1000).toFixed(1) + " kg" : r.co2.toFixed(0) + " g";
+      const pct = Math.round((r.co2 / maxCo2) * 100);
+      return (
+        '<div class="bar-row">' +
+        '<span class="bar-label">' + months[r.monthIndex] + "</span>" +
+        '<div class="bar-track"><div class="bar-fill" style="width: ' + pct + '%"></div></div>' +
+        '<span class="bar-value">' + display + "</span>" +
+        "</div>\n"
+      );
+    })
+    .join("");
+
+for (const [file, months] of [[summaryFr, MONTHS_FR], [summaryEn, MONTHS_EN]]) {
+  if (!file || !fs.existsSync(file)) continue;
+  fs.writeFileSync(file, fs.readFileSync(file, "utf8").replace("{{MONTHLY_BARS}}", barsFor(months)));
+}
+NODEEOF
 
 rm -f "$TMP_MONTHLY"
 
@@ -447,9 +437,29 @@ fi
 echo "Exporting PNGs via Playwright..."
 
 PORT=8799
-# Copy logo to /tmp so the HTTP server can serve it
-cp -f "$TEMPLATE_DIR/logo.png" /tmp/logo.png 2>/dev/null || true
-python3 -m http.server "$PORT" --directory /tmp &>/dev/null &
+# Copy the logo next to the pages so the server can serve it
+cp -f "$TEMPLATE_DIR/logo.png" "${CC_TMP}/logo.png" 2>/dev/null || true
+# Static file server in node rather than `python3 -m http.server`: a stock Windows
+# has no python3, and node is already required just above for Playwright. It also
+# binds the loopback interface only, where http.server defaulted to 0.0.0.0 and
+# briefly published these pages to the local network.
+CC_SERVE_DIR="$CC_TMP" CC_SERVE_PORT="$PORT" node -e '
+const http = require("http"), fs = require("fs"), path = require("path");
+const root = process.env.CC_SERVE_DIR;
+const types = { ".html": "text/html; charset=utf-8", ".png": "image/png", ".css": "text/css", ".js": "text/javascript", ".svg": "image/svg+xml" };
+http
+  .createServer((req, res) => {
+    // basename(): the only files ever requested sit directly in the scratch dir,
+    // and it forecloses any "../" walk out of it.
+    const name = path.basename(decodeURIComponent(req.url.split("?")[0]));
+    fs.readFile(path.join(root, name), (err, buf) => {
+      if (err) { res.writeHead(404); res.end(); return; }
+      res.writeHead(200, { "Content-Type": types[path.extname(name).toLowerCase()] || "application/octet-stream" });
+      res.end(buf);
+    });
+  })
+  .listen(Number(process.env.CC_SERVE_PORT), "127.0.0.1");
+' >/dev/null 2>&1 &
 SERVER_PID=$!
 # A function rather than a quoted trap string: the paths stay quoted, so a temp dir containing
 # a space cannot split them into separate arguments to rm.
@@ -466,10 +476,12 @@ export_png() {
   local html_file="$1" output="$2" label="$3"
   local filename url
   filename="$(basename "$html_file")"
-  url="http://localhost:${PORT}/${filename}"
+  url="http://127.0.0.1:${PORT}/${filename}"
 
+  # node is a native binary: a "/c/Users/…" MSYS path means nothing to it, so both
+  # the module path and the screenshot target go through cc_native_path first.
   node -e "
-const { chromium } = require('${PW_PATH}');
+const { chromium } = require('$(cc_native_path "$PW_PATH")');
 (async () => {
   const browser = await chromium.launch();
   const page = await browser.newPage({
@@ -479,7 +491,7 @@ const { chromium } = require('${PW_PATH}');
   await page.goto('${url}', { waitUntil: 'networkidle' });
   await page.waitForTimeout(2000);
   await page.screenshot({
-    path: '${output}',
+    path: '$(cc_native_path "$output")',
     clip: { x: 0, y: 0, width: 1080, height: 1080 }
   });
   await browser.close();

--- a/scripts/persist-session.sh
+++ b/scripts/persist-session.sh
@@ -10,10 +10,14 @@
 # Intentionally no set -euo pipefail: this hook must exit 0 silently in all cases.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/portable-lib.sh
+. "${SCRIPT_DIR}/portable-lib.sh"
 FACTORS_FILE="${SCRIPT_DIR}/../data/factors.json"
 PRICES_FILE="${SCRIPT_DIR}/../data/prices.json"
-CONFIG_DIR="${CLAUDE_CONFIG_DIR:-${HOME}/.claude}"
-DB_PATH="${CLAUDE_CARBON_DB:-${CONFIG_DIR}/claude-carbon/carbon.db}"
+# CLAUDE_CONFIG_DIR and CLAUDE_CARBON_DB are set by the user, so on Windows they
+# arrive in whatever spelling that user typed, native path included.
+CONFIG_DIR="$(cc_path "${CLAUDE_CONFIG_DIR:-${HOME}/.claude}")"
+DB_PATH="$(cc_path "${CLAUDE_CARBON_DB:-${CONFIG_DIR}/claude-carbon/carbon.db}")"
 
 METHODOLOGY_VERSION=2
 
@@ -77,8 +81,12 @@ INPUT="$(cat 2>/dev/null)" || exit 0
 SESSION_ID="$(echo "$INPUT" | jq -r '.session_id // ""' 2>/dev/null)" || exit 0
 [ -n "$SESSION_ID" ] || exit 0
 
+# Claude Code is a native binary: on Windows both of these arrive as
+# "C:\\Users\\me\\...", which bash cannot open. cc_path converts them.
 TRANSCRIPT_PATH="$(echo "$INPUT" | jq -r '.transcript_path // ""' 2>/dev/null)" || exit 0
+TRANSCRIPT_PATH="$(cc_path "$TRANSCRIPT_PATH")"
 CURRENT_DIR="$(echo "$INPUT" | jq -r '.cwd // ""' 2>/dev/null)" || exit 0
+CURRENT_DIR="$(cc_path "$CURRENT_DIR")"
 
 # Helper: aggregate tokens from a JSONL file.
 # Dedups assistant messages by (message.id|requestId) keeping the LAST occurrence; tracks

--- a/scripts/portable-lib.sh
+++ b/scripts/portable-lib.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+# portable-lib.sh — cross-platform helpers shared by every claude-carbon script.
+# Targets macOS, Linux, and native Windows through the Git Bash that Claude Code
+# spawns for hooks and the status line (see README "Windows").
+#
+# Sourced, never executed. It deliberately sets no shell options: each caller owns
+# its own error policy (the Stop hook, for one, must never abort).
+
+# Idempotent: several libs source this one, and a script may pull in more than
+# one of them. Spelled as a full `if` rather than `[ … ] && return 0`, whose
+# non-zero status on the first source would abort a caller running under `set -e`.
+# `return` (not `exit`) — this file is only ever sourced.
+if [ -n "${CC_PORTABLE_LIB:-}" ]; then
+  return 0
+fi
+CC_PORTABLE_LIB=1
+
+# ── Platform ────────────────────────────────────────────────────────────────
+# CC_OS is resolved once at source time, without a subshell: the status line runs
+# this on every turn, so a `uname` spawn per call would be felt. $OSTYPE is a bash
+# builtin variable and reads "msys" under Git Bash, "cygwin" under Cygwin.
+case "${OSTYPE:-}" in
+  darwin*)         CC_OS="darwin" ;;
+  msys*|cygwin*)   CC_OS="windows" ;;
+  linux*)          CC_OS="linux" ;;
+  *)
+    case "$(uname -s 2>/dev/null || echo unknown)" in
+      Darwin)                   CC_OS="darwin" ;;
+      MINGW*|MSYS*|CYGWIN*)     CC_OS="windows" ;;
+      *)                        CC_OS="linux" ;;
+    esac
+    ;;
+esac
+
+# cc_is_windows — true when running under Git Bash / MSYS / Cygwin on Windows.
+cc_is_windows() { [ "$CC_OS" = "windows" ]; }
+
+# ── Paths ───────────────────────────────────────────────────────────────────
+# Claude Code is a native Windows binary: the JSON it pipes into hooks and the
+# status line carries native paths ("C:\Users\me\.claude\projects\...\x.jsonl"),
+# and ${CLAUDE_PLUGIN_ROOT} expands the same way. Bash cannot open those: the
+# backslashes are escape characters, and the drive letter is not a mount point.
+# Every path that crosses that boundary goes through cc_path first.
+#
+# cygpath ships with Git for Windows and is the authority (it knows the actual
+# mount table, which a string rewrite does not). The manual fallback covers the
+# rare install where it is missing.
+CC_CYGPATH=""
+if [ "$CC_OS" = "windows" ] && command -v cygpath >/dev/null 2>&1; then
+  CC_CYGPATH="cygpath"
+fi
+
+# cc_path <path> — echoes a path bash can open. Identity on macOS and Linux, and
+# on Windows for a path that is already POSIX (the common case once inside the
+# scripts, so the cygpath spawn is paid only on the way in).
+cc_path() {
+  local p="${1:-}"
+  [ -n "$p" ] || return 0
+  if [ "$CC_OS" != "windows" ]; then
+    printf '%s' "$p"
+    return 0
+  fi
+  case "$p" in
+    [A-Za-z]:[\\/]*|*\\*)
+      if [ -n "$CC_CYGPATH" ]; then
+        local converted
+        if converted="$($CC_CYGPATH -u "$p" 2>/dev/null)" && [ -n "$converted" ]; then
+          printf '%s' "$converted"
+          return 0
+        fi
+      fi
+      # "C:\Users\me" → "/c/Users/me". Matches the default MSYS mount layout.
+      p="${p//\\//}"
+      case "$p" in
+        [A-Za-z]:/*)
+          local drive="${p%%:*}"
+          printf '/%s%s' "$(printf '%s' "$drive" | tr 'A-Z' 'a-z')" "${p#*:}"
+          ;;
+        *) printf '%s' "$p" ;;
+      esac
+      ;;
+    *) printf '%s' "$p" ;;
+  esac
+}
+
+# cc_native_path <path> — the inverse of cc_path: echoes a path that the native
+# Windows side understands, in the "mixed" spelling ("C:/Users/me/x"). Forward
+# slashes, so bash can also open it verbatim without escaping. Used for the paths
+# we hand back to Claude Code in settings.json, which it may resolve itself with
+# Windows APIs before spawning Git Bash. Identity on macOS and Linux.
+cc_native_path() {
+  local p="${1:-}"
+  [ -n "$p" ] || return 0
+  if [ "$CC_OS" != "windows" ] || [ -z "$CC_CYGPATH" ]; then
+    printf '%s' "$p"
+    return 0
+  fi
+  local converted
+  if converted="$($CC_CYGPATH -m "$p" 2>/dev/null)" && [ -n "$converted" ]; then
+    printf '%s' "$converted"
+  else
+    printf '%s' "$p"
+  fi
+}
+
+# cc_tmpdir — writable scratch directory. Git Bash provides /tmp, but a Windows
+# TMPDIR pointing at "C:\Users\ME~1\AppData\Local\Temp" must still be usable.
+cc_tmpdir() {
+  local d="${TMPDIR:-/tmp}"
+  d="$(cc_path "$d")"
+  d="${d%/}"
+  [ -d "$d" ] || d="/tmp"
+  printf '%s' "$d"
+}
+
+# ── Numbers ─────────────────────────────────────────────────────────────────
+# bc is absent from Git for Windows and from a bare Debian image. awk is present
+# everywhere the rest of this tool already needs it, so the float comparisons go
+# through awk instead of adding a dependency users must install.
+
+# cc_num_ge <a> <b> — exit 0 when a >= b, comparing as floats.
+cc_num_ge() {
+  LC_ALL=C awk -v a="${1:-0}" -v b="${2:-0}" 'BEGIN { exit !(a + 0 >= b + 0) }'
+}
+
+# ── Filesystem ──────────────────────────────────────────────────────────────
+# cc_mtime <file> — modification time in epoch seconds, 0 when unavailable.
+# BSD stat first (macOS, the majority of installs): GNU stat then costs a second
+# spawn only on Linux and Git Bash.
+cc_mtime() {
+  stat -f %m "$1" 2>/dev/null || stat -c %Y "$1" 2>/dev/null || echo 0
+}
+
+# cc_link_or_copy <src> <dst> — symlink where symlinks work, copy where they do
+# not. Git Bash silently degrades `ln -s` to a copy unless Windows Developer Mode
+# is on, so doing the copy ourselves keeps the outcome predictable; the caller is
+# responsible for refreshing copies on update (see update.sh).
+cc_link_or_copy() {
+  if [ "$CC_OS" = "windows" ]; then
+    cp -f "$1" "$2"
+  else
+    ln -s "$1" "$2"
+  fi
+}
+
+# ── Dependencies ────────────────────────────────────────────────────────────
+# cc_install_hint <command> — echoes the install line to show a user who is
+# missing that command, in the package manager their platform actually has.
+# Git for Windows ships bash, awk, sed, grep, date, curl and git, but neither
+# jq nor sqlite3, so those two are the whole Windows prerequisite list.
+cc_install_hint() {
+  local cmd="$1"
+  case "$CC_OS" in
+    darwin) printf 'brew install %s' "$cmd" ;;
+    windows)
+      case "$cmd" in
+        jq)      printf 'winget install jqlang.jq' ;;
+        sqlite3) printf 'winget install SQLite.SQLite' ;;
+        git)     printf 'winget install Git.Git' ;;
+        node)    printf 'winget install OpenJS.NodeJS' ;;
+        *)       printf 'winget install %s' "$cmd" ;;
+      esac
+      ;;
+    *) printf 'apt install %s' "$cmd" ;;
+  esac
+}
+
+# ── Locale ──────────────────────────────────────────────────────────────────
+# cc_system_locale — the OS-level locale, for shells that carry no LANG at all
+# (macOS GUI-launched hooks, and every Windows shell). Empty when unknown.
+cc_system_locale() {
+  case "$CC_OS" in
+    darwin)
+      defaults read -g AppleLocale 2>/dev/null || true
+      ;;
+    windows)
+      # reg.exe is ~10x cheaper than spawning PowerShell for one property.
+      # Output: "    LocaleName    REG_SZ    fr-FR"
+      reg query "HKCU\\Control Panel\\International" //v LocaleName 2>/dev/null \
+        | LC_ALL=C awk '/LocaleName/ { print $NF }' || true
+      ;;
+  esac
+}

--- a/scripts/recompute.sh
+++ b/scripts/recompute.sh
@@ -25,9 +25,11 @@ set -euo pipefail
 # model. This is not a small approximation on subagent-heavy workloads; see the note above.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/portable-lib.sh
+. "${SCRIPT_DIR}/portable-lib.sh"
 FACTORS_FILE="${CLAUDE_CARBON_FACTORS:-${SCRIPT_DIR}/../data/factors.json}"
 PRICES_FILE="${CLAUDE_CARBON_PRICES:-${SCRIPT_DIR}/../data/prices.json}"
-DB_PATH="${CLAUDE_CARBON_DB:-${CLAUDE_CONFIG_DIR:-${HOME}/.claude}/claude-carbon/carbon.db}"
+DB_PATH="$(cc_path "${CLAUDE_CARBON_DB:-${CLAUDE_CONFIG_DIR:-${HOME}/.claude}/claude-carbon/carbon.db}")"
 
 [ -f "$DB_PATH" ] || { echo "No database at ${DB_PATH}" >&2; exit 1; }
 

--- a/scripts/safety-rescan.sh
+++ b/scripts/safety-rescan.sh
@@ -6,8 +6,10 @@
 # Must exit 0 immediately and never block session start.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-DB_DIR="${CLAUDE_CONFIG_DIR:-${HOME}/.claude}/claude-carbon"
-DB_PATH="${CLAUDE_CARBON_DB:-${DB_DIR}/carbon.db}"
+# shellcheck source=scripts/portable-lib.sh
+. "${SCRIPT_DIR}/portable-lib.sh"
+DB_DIR="$(cc_path "${CLAUDE_CONFIG_DIR:-${HOME}/.claude}")/claude-carbon"
+DB_PATH="$(cc_path "${CLAUDE_CARBON_DB:-${DB_DIR}/carbon.db}")"
 STAMP="${DB_DIR}/.last-rescan"
 
 # Portable detach: fully background a command so it survives session-start exit. setsid is
@@ -44,7 +46,7 @@ fi
 
 # Throttle: skip if a rescan ran in the last 24h
 if [ -f "$STAMP" ]; then
-  MTIME="$(stat -f %m "$STAMP" 2>/dev/null || stat -c %Y "$STAMP" 2>/dev/null || echo 0)"
+  MTIME="$(cc_mtime "$STAMP")"
   AGE=$(( $(date +%s) - MTIME ))
   [ "$AGE" -lt 86400 ] && exit 0
 fi

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -4,8 +4,10 @@ set -euo pipefail
 # setup.sh — Initialize claude-carbon: check deps, create DB, backfill history, show summary.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/portable-lib.sh
+. "${SCRIPT_DIR}/portable-lib.sh"
 PLUGIN_DIR="$(dirname "$SCRIPT_DIR")"
-CONFIG_DIR="${CLAUDE_CONFIG_DIR:-${HOME}/.claude}"
+CONFIG_DIR="$(cc_path "${CLAUDE_CONFIG_DIR:-${HOME}/.claude}")"
 DB_DIR="${CONFIG_DIR}/claude-carbon"
 DB_PATH="${DB_DIR}/carbon.db"
 
@@ -15,18 +17,13 @@ echo "────────────────────────�
 # 1. Check dependencies
 echo "Checking dependencies..."
 
-if ! command -v jq &>/dev/null; then
-  echo "ERROR: jq is not installed. Install with: brew install jq" >&2
-  exit 1
-fi
-
-if ! command -v sqlite3 &>/dev/null; then
-  echo "ERROR: sqlite3 is not installed. Install with: brew install sqlite3" >&2
-  exit 1
-fi
-
-echo "  jq: OK"
-echo "  sqlite3: OK"
+for CMD in jq sqlite3; do
+  if ! command -v "$CMD" &>/dev/null; then
+    echo "ERROR: $CMD is not installed. Install with: $(cc_install_hint "$CMD")" >&2
+    exit 1
+  fi
+  echo "  ${CMD}: OK"
+done
 
 # 2. Create directory
 echo ""
@@ -106,6 +103,7 @@ if [ "${CLAUDE_CARBON_INSTALLER:-}" != "1" ]; then
   echo "─────────────────────────────"
   echo "Next steps:"
   echo ""
+  PLUGIN_DIR="$(cc_native_path "$PLUGIN_DIR")"
   echo "1. Add to ${CONFIG_DIR}/settings.json:"
   echo ""
   cat <<EOF

--- a/scripts/statusline.sh
+++ b/scripts/statusline.sh
@@ -10,9 +10,11 @@ SEGMENT_MODE=0
 [ "${1:-}" = "--segment" ] && SEGMENT_MODE=1
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/portable-lib.sh
+. "${SCRIPT_DIR}/portable-lib.sh"
 FACTORS_FILE="${SCRIPT_DIR}/../data/factors.json"
-CONFIG_DIR="${CLAUDE_CONFIG_DIR:-${HOME}/.claude}"
-DB_PATH="${CLAUDE_CARBON_DB:-${CONFIG_DIR}/claude-carbon/carbon.db}"
+CONFIG_DIR="$(cc_path "${CLAUDE_CONFIG_DIR:-${HOME}/.claude}")"
+DB_PATH="$(cc_path "${CLAUDE_CARBON_DB:-${CONFIG_DIR}/claude-carbon/carbon.db}")"
 
 # Read stdin
 INPUT="$(cat)"
@@ -24,7 +26,9 @@ INPUT_TOKENS="$(echo "$INPUT" | jq -r '.context_window.total_input_tokens // 0')
 OUTPUT_TOKENS="$(echo "$INPUT" | jq -r '.context_window.total_output_tokens // 0')"
 COST_USD="$(echo "$INPUT" | jq -r '.cost.total_cost_usd // 0')"
 USED_PCT="$(echo "$INPUT" | jq -r '.context_window.used_percentage // 0')"
-CURRENT_DIR="$(echo "$INPUT" | jq -r '.workspace.current_dir // ""')"
+# Native path on Windows ("C:\\Users\\me\\code\\x"): basename and `git -C`
+# both need it converted first.
+CURRENT_DIR="$(cc_path "$(echo "$INPUT" | jq -r '.workspace.current_dir // ""')")"
 SESSION_ID="$(echo "$INPUT" | jq -r '.session_id // ""')"
 
 # Project name = last path segment
@@ -126,7 +130,7 @@ if command -v jq &>/dev/null; then
 
     NEEDS_REFRESH=1
     if [ -f "$USAGE_CACHE_FILE" ]; then
-      CACHE_MTIME="$(stat -f %m "$USAGE_CACHE_FILE" 2>/dev/null || stat -c %Y "$USAGE_CACHE_FILE" 2>/dev/null || echo 0)"
+      CACHE_MTIME="$(cc_mtime "$USAGE_CACHE_FILE")"
       CACHE_AGE=$(( $(date +%s) - CACHE_MTIME ))
       [ "$CACHE_AGE" -lt "$USAGE_CACHE_TTL" ] && NEEDS_REFRESH=0
     fi
@@ -135,7 +139,7 @@ if command -v jq &>/dev/null; then
       TOKEN=""
       if [ -n "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]; then
         TOKEN="$CLAUDE_CODE_OAUTH_TOKEN"
-      elif command -v security &>/dev/null; then
+      elif [ "$CC_OS" = "darwin" ] && command -v security &>/dev/null; then
         BLOB="$(security find-generic-password -s "Claude Code-credentials" -w 2>/dev/null || true)"
         [ -n "$BLOB" ] && TOKEN="$(echo "$BLOB" | jq -r '.claudeAiOauth.accessToken // empty' 2>/dev/null)"
       fi

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -6,8 +6,10 @@
 set -uo pipefail   # NOT -e: each git step is handled explicitly
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/portable-lib.sh
+. "${SCRIPT_DIR}/portable-lib.sh"
 REPO_DIR="$(dirname "$SCRIPT_DIR")"
-STATE_DIR="${CLAUDE_CONFIG_DIR:-${HOME}/.claude}/claude-carbon"
+STATE_DIR="$(cc_path "${CLAUDE_CONFIG_DIR:-${HOME}/.claude}")/claude-carbon"
 
 [ -d "${REPO_DIR}/.git" ] || { echo "Not a git-clone install; nothing to update." >&2; exit 0; }
 case "$REPO_DIR" in
@@ -60,7 +62,7 @@ bash "${SCRIPT_DIR}/configure-settings.sh" >/dev/null 2>&1 || true
 # Refresh the DB schema, then re-price history (CO2-only by default: cheap, idempotent,
 # no mixed-model cost drift).
 CLAUDE_CARBON_INSTALLER=1 bash "${SCRIPT_DIR}/setup.sh" >/dev/null 2>&1 || true
-DB_PATH="${CLAUDE_CARBON_DB:-${STATE_DIR}/carbon.db}"
+DB_PATH="$(cc_path "${CLAUDE_CARBON_DB:-${STATE_DIR}/carbon.db}")"
 if [ -f "$DB_PATH" ]; then
   bash "${SCRIPT_DIR}/recompute.sh" || echo "history not re-priced; see message above."
 fi

--- a/skills/carbon-badge/SKILL.md
+++ b/skills/carbon-badge/SKILL.md
@@ -9,16 +9,26 @@ Run the following bash script and present the output to the user.
 #!/usr/bin/env bash
 # Locate the install wired into the status line (honours CLAUDE_CONFIG_DIR),
 # then fall back to CLAUDE_PLUGIN_ROOT / CLAUDE_CARBON_DIR / the default path.
-CFG="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+# Windows (Git Bash): CLAUDE_* variables and the paths stored in settings.json can
+# arrive in the native "C:\Users\..." spelling, which bash cannot open. cygpath
+# ships with Git for Windows; everywhere else this is the identity function.
+ccp() {
+  case "${OSTYPE:-}" in msys*|cygwin*) ;; *) printf '%s' "$1"; return 0 ;; esac
+  case "$1" in
+    [A-Za-z]:[\\/]*|*\\*) cygpath -u "$1" 2>/dev/null || printf '%s' "$1" ;;
+    *) printf '%s' "$1" ;;
+  esac
+}
+CFG="$(ccp "${CLAUDE_CONFIG_DIR:-$HOME/.claude}")"
 REPO_DIR=""
 if command -v jq >/dev/null 2>&1 && [ -f "$CFG/settings.json" ]; then
   SL_CMD="$(jq -r '.statusLine.command // empty' "$CFG/settings.json" 2>/dev/null)"
   # statusLine.command stores a shell-escaped path: expand ~ and unescape spaces
-  SL_CMD="${SL_CMD//\\ / }"; SL_CMD="${SL_CMD/#\~/$HOME}"
+  SL_CMD="${SL_CMD//\\ / }"; SL_CMD="${SL_CMD/#\~/$HOME}"; SL_CMD="$(ccp "$SL_CMD")"
   [ -n "$SL_CMD" ] && [ -f "$SL_CMD" ] && REPO_DIR="$(cd "$(dirname "$SL_CMD")/.." 2>/dev/null && pwd)"
 fi
-[ -z "$REPO_DIR" ] && [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && REPO_DIR="$CLAUDE_PLUGIN_ROOT"
-[ -z "$REPO_DIR" ] && [ -n "${CLAUDE_CARBON_DIR:-}" ] && REPO_DIR="$CLAUDE_CARBON_DIR"
+[ -z "$REPO_DIR" ] && [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && REPO_DIR="$(ccp "$CLAUDE_PLUGIN_ROOT")"
+[ -z "$REPO_DIR" ] && [ -n "${CLAUDE_CARBON_DIR:-}" ] && REPO_DIR="$(ccp "$CLAUDE_CARBON_DIR")"
 if [ -z "$REPO_DIR" ]; then
   # Pure marketplace installs reach here: no statusLine.command in settings.json and
   # no CLAUDE_PLUGIN_ROOT in a skill's bash env. Pick the newest cached plugin copy,

--- a/skills/carbon-card/SKILL.md
+++ b/skills/carbon-card/SKILL.md
@@ -9,16 +9,26 @@ Run the following bash script and present the output to the user. Show the expor
 #!/usr/bin/env bash
 # Locate the install wired into the status line (honours CLAUDE_CONFIG_DIR),
 # then fall back to CLAUDE_PLUGIN_ROOT / CLAUDE_CARBON_DIR / the default path.
-CFG="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+# Windows (Git Bash): CLAUDE_* variables and the paths stored in settings.json can
+# arrive in the native "C:\Users\..." spelling, which bash cannot open. cygpath
+# ships with Git for Windows; everywhere else this is the identity function.
+ccp() {
+  case "${OSTYPE:-}" in msys*|cygwin*) ;; *) printf '%s' "$1"; return 0 ;; esac
+  case "$1" in
+    [A-Za-z]:[\\/]*|*\\*) cygpath -u "$1" 2>/dev/null || printf '%s' "$1" ;;
+    *) printf '%s' "$1" ;;
+  esac
+}
+CFG="$(ccp "${CLAUDE_CONFIG_DIR:-$HOME/.claude}")"
 REPO_DIR=""
 if command -v jq >/dev/null 2>&1 && [ -f "$CFG/settings.json" ]; then
   SL_CMD="$(jq -r '.statusLine.command // empty' "$CFG/settings.json" 2>/dev/null)"
   # statusLine.command stores a shell-escaped path: expand ~ and unescape spaces
-  SL_CMD="${SL_CMD//\\ / }"; SL_CMD="${SL_CMD/#\~/$HOME}"
+  SL_CMD="${SL_CMD//\\ / }"; SL_CMD="${SL_CMD/#\~/$HOME}"; SL_CMD="$(ccp "$SL_CMD")"
   [ -n "$SL_CMD" ] && [ -f "$SL_CMD" ] && REPO_DIR="$(cd "$(dirname "$SL_CMD")/.." 2>/dev/null && pwd)"
 fi
-[ -z "$REPO_DIR" ] && [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && REPO_DIR="$CLAUDE_PLUGIN_ROOT"
-[ -z "$REPO_DIR" ] && [ -n "${CLAUDE_CARBON_DIR:-}" ] && REPO_DIR="$CLAUDE_CARBON_DIR"
+[ -z "$REPO_DIR" ] && [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && REPO_DIR="$(ccp "$CLAUDE_PLUGIN_ROOT")"
+[ -z "$REPO_DIR" ] && [ -n "${CLAUDE_CARBON_DIR:-}" ] && REPO_DIR="$(ccp "$CLAUDE_CARBON_DIR")"
 if [ -z "$REPO_DIR" ]; then
   # Pure marketplace installs reach here: no statusLine.command in settings.json and
   # no CLAUDE_PLUGIN_ROOT in a skill's bash env. Pick the newest cached plugin copy,

--- a/skills/carbon-pr/SKILL.md
+++ b/skills/carbon-pr/SKILL.md
@@ -9,16 +9,26 @@ Run the following bash script from the repository the PR belongs to, and present
 #!/usr/bin/env bash
 # Locate the install wired into the status line (honours CLAUDE_CONFIG_DIR),
 # then fall back to CLAUDE_PLUGIN_ROOT / CLAUDE_CARBON_DIR / the default path.
-CFG="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+# Windows (Git Bash): CLAUDE_* variables and the paths stored in settings.json can
+# arrive in the native "C:\Users\..." spelling, which bash cannot open. cygpath
+# ships with Git for Windows; everywhere else this is the identity function.
+ccp() {
+  case "${OSTYPE:-}" in msys*|cygwin*) ;; *) printf '%s' "$1"; return 0 ;; esac
+  case "$1" in
+    [A-Za-z]:[\\/]*|*\\*) cygpath -u "$1" 2>/dev/null || printf '%s' "$1" ;;
+    *) printf '%s' "$1" ;;
+  esac
+}
+CFG="$(ccp "${CLAUDE_CONFIG_DIR:-$HOME/.claude}")"
 REPO_DIR=""
 if command -v jq >/dev/null 2>&1 && [ -f "$CFG/settings.json" ]; then
   SL_CMD="$(jq -r '.statusLine.command // empty' "$CFG/settings.json" 2>/dev/null)"
   # statusLine.command stores a shell-escaped path: expand ~ and unescape spaces
-  SL_CMD="${SL_CMD//\\ / }"; SL_CMD="${SL_CMD/#\~/$HOME}"
+  SL_CMD="${SL_CMD//\\ / }"; SL_CMD="${SL_CMD/#\~/$HOME}"; SL_CMD="$(ccp "$SL_CMD")"
   [ -n "$SL_CMD" ] && [ -f "$SL_CMD" ] && REPO_DIR="$(cd "$(dirname "$SL_CMD")/.." 2>/dev/null && pwd)"
 fi
-[ -z "$REPO_DIR" ] && [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && REPO_DIR="$CLAUDE_PLUGIN_ROOT"
-[ -z "$REPO_DIR" ] && [ -n "${CLAUDE_CARBON_DIR:-}" ] && REPO_DIR="$CLAUDE_CARBON_DIR"
+[ -z "$REPO_DIR" ] && [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && REPO_DIR="$(ccp "$CLAUDE_PLUGIN_ROOT")"
+[ -z "$REPO_DIR" ] && [ -n "${CLAUDE_CARBON_DIR:-}" ] && REPO_DIR="$(ccp "$CLAUDE_CARBON_DIR")"
 if [ -z "$REPO_DIR" ]; then
   # Pure marketplace installs reach here: no statusLine.command in settings.json and
   # no CLAUDE_PLUGIN_ROOT in a skill's bash env. Pick the newest cached plugin copy,

--- a/skills/carbon-report/SKILL.md
+++ b/skills/carbon-report/SKILL.md
@@ -10,16 +10,26 @@ Run the following bash script exactly as written and present the output to the u
 
 # Locate the install (equivalence factors + shared locale lib live in the repo),
 # mirroring /carbon-card: status line wiring first, then plugin root, then default.
-CFG="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+# Windows (Git Bash): CLAUDE_* variables and the paths stored in settings.json can
+# arrive in the native "C:\Users\..." spelling, which bash cannot open. cygpath
+# ships with Git for Windows; everywhere else this is the identity function.
+ccp() {
+  case "${OSTYPE:-}" in msys*|cygwin*) ;; *) printf '%s' "$1"; return 0 ;; esac
+  case "$1" in
+    [A-Za-z]:[\\/]*|*\\*) cygpath -u "$1" 2>/dev/null || printf '%s' "$1" ;;
+    *) printf '%s' "$1" ;;
+  esac
+}
+CFG="$(ccp "${CLAUDE_CONFIG_DIR:-$HOME/.claude}")"
 REPO_DIR=""
 if command -v jq >/dev/null 2>&1 && [ -f "$CFG/settings.json" ]; then
   SL_CMD="$(jq -r '.statusLine.command // empty' "$CFG/settings.json" 2>/dev/null)"
   # statusLine.command stores a shell-escaped path: expand ~ and unescape spaces
-  SL_CMD="${SL_CMD//\\ / }"; SL_CMD="${SL_CMD/#\~/$HOME}"
+  SL_CMD="${SL_CMD//\\ / }"; SL_CMD="${SL_CMD/#\~/$HOME}"; SL_CMD="$(ccp "$SL_CMD")"
   [ -n "$SL_CMD" ] && [ -f "$SL_CMD" ] && REPO_DIR="$(cd "$(dirname "$SL_CMD")/.." 2>/dev/null && pwd)"
 fi
-[ -z "$REPO_DIR" ] && [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && REPO_DIR="$CLAUDE_PLUGIN_ROOT"
-[ -z "$REPO_DIR" ] && [ -n "${CLAUDE_CARBON_DIR:-}" ] && REPO_DIR="$CLAUDE_CARBON_DIR"
+[ -z "$REPO_DIR" ] && [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && REPO_DIR="$(ccp "$CLAUDE_PLUGIN_ROOT")"
+[ -z "$REPO_DIR" ] && [ -n "${CLAUDE_CARBON_DIR:-}" ] && REPO_DIR="$(ccp "$CLAUDE_CARBON_DIR")"
 if [ -z "$REPO_DIR" ]; then
   # Pure marketplace installs reach here: settings.json carries no statusLine.command
   # (the status line is wired through plugin.json) and CLAUDE_PLUGIN_ROOT is not in the
@@ -51,7 +61,7 @@ EQUIV_SET="$(detect_equiv_set)"
 # "431.7045" as 431 and print "431,0" instead of "431.7"
 export LC_ALL=C
 
-DB_PATH="${CLAUDE_CARBON_DB:-${CLAUDE_CONFIG_DIR:-$HOME/.claude}/claude-carbon/carbon.db}"
+DB_PATH="$(ccp "${CLAUDE_CARBON_DB:-${CLAUDE_CONFIG_DIR:-$HOME/.claude}/claude-carbon/carbon.db}")"
 
 if [ ! -f "$DB_PATH" ]; then
   echo "Database not found. Run setup.sh first:"

--- a/skills/carbon-update/SKILL.md
+++ b/skills/carbon-update/SKILL.md
@@ -9,17 +9,27 @@ Run the following bash script exactly as written and present its output to the u
 #!/usr/bin/env bash
 # Locate the install that is actually wired into the status line, then run its updater.
 REPO_DIR=""
-SETTINGS="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/settings.json"
+# Windows (Git Bash): CLAUDE_* variables and the paths stored in settings.json can
+# arrive in the native "C:\Users\..." spelling, which bash cannot open. cygpath
+# ships with Git for Windows; everywhere else this is the identity function.
+ccp() {
+  case "${OSTYPE:-}" in msys*|cygwin*) ;; *) printf '%s' "$1"; return 0 ;; esac
+  case "$1" in
+    [A-Za-z]:[\\/]*|*\\*) cygpath -u "$1" 2>/dev/null || printf '%s' "$1" ;;
+    *) printf '%s' "$1" ;;
+  esac
+}
+SETTINGS="$(ccp "${CLAUDE_CONFIG_DIR:-$HOME/.claude}")/settings.json"
 if command -v jq >/dev/null 2>&1 && [ -f "$SETTINGS" ]; then
   SL_CMD="$(jq -r '.statusLine.command // empty' "$SETTINGS" 2>/dev/null)"
   # statusLine.command stores a shell-escaped path: expand ~ and unescape spaces
-  SL_CMD="${SL_CMD//\\ / }"; SL_CMD="${SL_CMD/#\~/$HOME}"
+  SL_CMD="${SL_CMD//\\ / }"; SL_CMD="${SL_CMD/#\~/$HOME}"; SL_CMD="$(ccp "$SL_CMD")"
   if [ -n "$SL_CMD" ] && [ -f "$SL_CMD" ]; then
     REPO_DIR="$(cd "$(dirname "$SL_CMD")/.." 2>/dev/null && pwd)"
   fi
 fi
-[ -z "$REPO_DIR" ] && [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && REPO_DIR="$CLAUDE_PLUGIN_ROOT"
-[ -z "$REPO_DIR" ] && REPO_DIR="${CLAUDE_CARBON_DIR:-$HOME/code/claude-carbon}"
+[ -z "$REPO_DIR" ] && [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && REPO_DIR="$(ccp "$CLAUDE_PLUGIN_ROOT")"
+[ -z "$REPO_DIR" ] && REPO_DIR="$(ccp "${CLAUDE_CARBON_DIR:-$HOME/code/claude-carbon}")"
 
 if [ -f "${REPO_DIR}/scripts/update.sh" ]; then
   bash "${REPO_DIR}/scripts/update.sh"

--- a/tests/run-badge-tests.sh
+++ b/tests/run-badge-tests.sh
@@ -9,7 +9,7 @@
 # ~/.claude is never read or written.
 #
 # bash 3.2 compatible (macOS default): no associative arrays, no mapfile.
-# Dependencies: sqlite3, bc.
+# Dependencies: sqlite3, awk.
 
 set -u
 
@@ -18,10 +18,14 @@ REPO_DIR="$(dirname "$SCRIPT_DIR")"
 BADGE="${REPO_DIR}/scripts/generate-badge.sh"
 
 command -v sqlite3 >/dev/null 2>&1 || { echo "FAIL: sqlite3 is required" >&2; exit 1; }
-command -v bc      >/dev/null 2>&1 || { echo "FAIL: bc is required" >&2; exit 1; }
+command -v awk     >/dev/null 2>&1 || { echo "FAIL: awk is required" >&2; exit 1; }
 [ -f "$BADGE" ] || { echo "FAIL: missing $BADGE" >&2; exit 1; }
 
-TMPROOT="$(mktemp -d "${TMPDIR:-/tmp}/claude-carbon-badge-tests.XXXXXX")"
+# cc_tmpdir rather than $TMPDIR directly: under Git Bash on Windows TMPDIR can
+# hold a native "C:\Users\..." path, which mktemp cannot use as a template.
+# shellcheck source=scripts/portable-lib.sh
+. "${REPO_DIR}/scripts/portable-lib.sh"
+TMPROOT="$(mktemp -d "$(cc_tmpdir)/claude-carbon-badge-tests.XXXXXX")"
 TMPROOT="$(cd "$TMPROOT" && pwd -P)"
 
 # Only ever delete a path we just created under a temp root, never an arbitrary variable.

--- a/tests/run-install-ps1-tests.ps1
+++ b/tests/run-install-ps1-tests.ps1
@@ -158,3 +158,6 @@ Write-Host "-----------------------------"
 Write-Host "passed: $($script:Passed)   failed: $($script:Failed)"
 if ($script:Failed -gt 0) { exit 1 }
 Write-Host "All $($script:Passed) install.ps1 assertions passed."
+# Explicit: with no `exit`, PowerShell hands back $LASTEXITCODE, and the last thing
+# this suite ran on purpose was a stub installer that exits non-zero.
+exit 0

--- a/tests/run-install-ps1-tests.ps1
+++ b/tests/run-install-ps1-tests.ps1
@@ -117,10 +117,37 @@ http.createServer((req, res) => {
 }).listen(8791, "127.0.0.1");
 '@ | Set-Content -Path $serverJs -Encoding UTF8
 
-$server = Start-Process node -ArgumentList $serverJs, $serveDir -PassThru -WindowStyle Hidden
-Start-Sleep -Milliseconds 700
+$serverLog = Join-Path $tempRoot 'server.log'
+$serverErr = Join-Path $tempRoot 'server.err'
+$server = Start-Process node -ArgumentList $serverJs, $serveDir -PassThru -WindowStyle Hidden `
+    -RedirectStandardOutput $serverLog -RedirectStandardError $serverErr
+
+# Poll rather than sleep a fixed interval. A fixed 700ms passed once and failed the
+# next run on the same code, and a stub server that is merely slow then surfaces as
+# four unrelated assertion failures instead of one honest "the harness is not ready".
+$ready = $false
+foreach ($attempt in 1..50) {
+    try {
+        $probe = New-Object System.Net.Sockets.TcpClient
+        $probe.Connect('127.0.0.1', 8791)
+        $probe.Close()
+        $ready = $true
+        break
+    } catch {
+        Start-Sleep -Milliseconds 200
+    }
+}
+Assert-Equal "stub server accepting connections" $true $ready
+if (-not $ready) {
+    Write-Host "       node stdout: $(Get-Content $serverLog -Raw -ErrorAction SilentlyContinue)"
+    Write-Host "       node stderr: $(Get-Content $serverErr -Raw -ErrorAction SilentlyContinue)"
+    Write-Host "       node exited: $($server.HasExited)"
+}
 
 try {
+  if (-not $ready) {
+    Write-Host "SKIP handover assertions: the stub server never came up."
+  } else {
     $env:CLAUDE_CARBON_INSTALL_URL = 'http://127.0.0.1:8791/install.sh'
     $output = & powershell -NoProfile -ExecutionPolicy Bypass -File $InstallPs1 2>&1 | Out-String
     $code = $LASTEXITCODE
@@ -146,6 +173,7 @@ try {
     $missOut = & powershell -NoProfile -ExecutionPolicy Bypass -File $InstallPs1 2>&1 | Out-String
     Assert-Contains "reports a download failure"     "could not download"   $missOut
     Assert-Equal    "non-zero exit on download failure" $true               ($LASTEXITCODE -ne 0)
+  }
 }
 finally {
     Remove-Item Env:\CLAUDE_CARBON_INSTALL_URL -ErrorAction SilentlyContinue

--- a/tests/run-install-ps1-tests.ps1
+++ b/tests/run-install-ps1-tests.ps1
@@ -1,0 +1,160 @@
+# run-install-ps1-tests.ps1 - exercise the Windows bootstrap.
+#
+# install.ps1 is the one file in this repo that no POSIX machine can even parse, so
+# it is the piece most likely to rot unnoticed. This suite runs on windows-latest and
+# covers everything install.ps1 owns: it parses, it finds the Git Bash that Claude
+# Code will also use, it resolves the two dependencies through that bash's own PATH,
+# it normalises the downloaded installer's line endings, it hands over, and it
+# propagates the installer's exit code.
+#
+# The handover target is stubbed over local HTTP, so nothing is cloned and no real
+# installation happens. Requires: Git for Windows, node (test harness only).
+
+$ErrorActionPreference = 'Stop'
+
+$RepoDir    = Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path)
+$InstallPs1 = Join-Path $RepoDir 'install.ps1'
+
+$script:Passed = 0
+$script:Failed = 0
+
+function Assert-Equal($name, $expected, $actual) {
+    if ($expected -eq $actual) {
+        $script:Passed++; Write-Host "PASS $name"
+    } else {
+        $script:Failed++
+        Write-Host "FAIL $name"
+        Write-Host "       expected: $expected"
+        Write-Host "       actual:   $actual"
+    }
+}
+
+function Assert-Contains($name, $needle, $haystack) {
+    if ($haystack -and $haystack -match [regex]::Escape($needle)) {
+        $script:Passed++; Write-Host "PASS $name"
+    } else {
+        $script:Failed++
+        Write-Host "FAIL $name"
+        Write-Host "       expected to contain: $needle"
+        Write-Host "       actual:              $haystack"
+    }
+}
+
+Write-Host "install.ps1 tests"
+Write-Host "-----------------------------"
+
+# -- 1. It parses -------------------------------------------------------------
+# A syntax error here would only ever surface on a user's machine, mid-install.
+Write-Host ""
+Write-Host "syntax"
+
+$tokens = $null
+$errors = $null
+[System.Management.Automation.Language.Parser]::ParseFile($InstallPs1, [ref]$tokens, [ref]$errors) | Out-Null
+Assert-Equal "install.ps1 parses without errors" 0 $errors.Count
+if ($errors.Count -gt 0) { $errors | ForEach-Object { Write-Host "       $($_.Message)" } }
+
+# -- 2. Git Bash discovery ----------------------------------------------------
+# Reuse the script's own function rather than a copy of it, so the test cannot pass
+# against logic that no longer matches what ships.
+Write-Host ""
+Write-Host "Git Bash discovery"
+
+$source = Get-Content $InstallPs1 -Raw
+$funcMatch = [regex]::Match($source, '(?ms)^function Find-GitBash \{.*?^\}')
+Assert-Equal "Find-GitBash extracted from install.ps1" $true $funcMatch.Success
+if ($funcMatch.Success) {
+    Invoke-Expression $funcMatch.Value
+    $bash = Find-GitBash
+    Assert-Equal   "Git Bash located"            $true ([bool]$bash)
+    Assert-Equal   "located bash.exe exists"     $true (Test-Path -LiteralPath $bash -PathType Leaf)
+    # System32\bash.exe launches WSL: installing through it would land in the Linux
+    # distribution instead of on Windows.
+    Assert-Equal   "did not pick the WSL launcher" $false ($bash -match '\\System32\\')
+
+    # The env var Claude Code itself reads must win, so a user who already pointed
+    # Claude Code at a non-default Git install does not have to say it twice.
+    $env:CLAUDE_CODE_GIT_BASH_PATH = $bash
+    Assert-Equal   "CLAUDE_CODE_GIT_BASH_PATH honoured" $bash (Find-GitBash)
+    Remove-Item Env:\CLAUDE_CODE_GIT_BASH_PATH -ErrorAction SilentlyContinue
+
+    # A path that does not exist must be ignored rather than returned blindly.
+    $env:CLAUDE_CODE_GIT_BASH_PATH = 'C:\definitely\not\here\bash.exe'
+    $fallback = Find-GitBash
+    Assert-Equal   "a bogus override falls through" $true (Test-Path -LiteralPath $fallback -PathType Leaf)
+    Remove-Item Env:\CLAUDE_CODE_GIT_BASH_PATH -ErrorAction SilentlyContinue
+}
+
+# -- 3. End to end against a stubbed installer --------------------------------
+Write-Host ""
+Write-Host "handover to install.sh"
+
+$tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("cc-ps1-tests-" + [System.Guid]::NewGuid().ToString('N').Substring(0, 8))
+New-Item -ItemType Directory -Path $tempRoot -Force | Out-Null
+$serveDir = Join-Path $tempRoot 'serve'
+New-Item -ItemType Directory -Path $serveDir -Force | Out-Null
+
+# Deliberately CRLF: this is what a misconfigured host or a browser download would
+# hand back, and bash would fail on the carriage returns unless install.ps1 strips
+# them. The stub also echoes its own argv so we can see it ran under bash.
+$stub = "#!/usr/bin/env bash`r`necho STUB_INSTALLER_RAN`r`nexit 0`r`n"
+[System.IO.File]::WriteAllText((Join-Path $serveDir 'install.sh'), $stub)
+
+$failingStub = "#!/usr/bin/env bash`necho STUB_FAILED`nexit 7`n"
+[System.IO.File]::WriteAllText((Join-Path $serveDir 'failing.sh'), $failingStub)
+
+$serverJs = Join-Path $tempRoot 'server.js'
+@'
+const http = require("http"), fs = require("fs"), path = require("path");
+const root = process.argv[2];
+http.createServer((req, res) => {
+  const name = path.basename(req.url.split("?")[0]);
+  fs.readFile(path.join(root, name), (err, buf) => {
+    if (err) { res.writeHead(404); res.end(); return; }
+    res.writeHead(200, { "Content-Type": "text/plain" });
+    res.end(buf);
+  });
+}).listen(8791, "127.0.0.1");
+'@ | Set-Content -Path $serverJs -Encoding UTF8
+
+$server = Start-Process node -ArgumentList $serverJs, $serveDir -PassThru -WindowStyle Hidden
+Start-Sleep -Milliseconds 700
+
+try {
+    $env:CLAUDE_CARBON_INSTALL_URL = 'http://127.0.0.1:8791/install.sh'
+    $output = & powershell -NoProfile -ExecutionPolicy Bypass -File $InstallPs1 2>&1 | Out-String
+    $code = $LASTEXITCODE
+
+    Assert-Contains "reports the Git Bash it found"  "Git Bash:"            $output
+    Assert-Contains "checks jq"                      "jq: OK"               $output
+    Assert-Contains "checks sqlite3"                 "sqlite3: OK"          $output
+    Assert-Contains "hands over to the installer"    "STUB_INSTALLER_RAN"   $output
+    Assert-Equal    "exit code 0 on success"         0                      $code
+
+    # The stub arrived with CRLF. Reaching STUB_INSTALLER_RAN at all proves the
+    # normalisation happened: bash would otherwise have failed on $'\r'.
+    Assert-Equal    "no carriage-return error"       $false                 ($output -match "\\r': command not found")
+
+    # A failing installer must not be reported as a success.
+    $env:CLAUDE_CARBON_INSTALL_URL = 'http://127.0.0.1:8791/failing.sh'
+    $failOut = & powershell -NoProfile -ExecutionPolicy Bypass -File $InstallPs1 2>&1 | Out-String
+    Assert-Contains "runs the failing stub"          "STUB_FAILED"          $failOut
+    Assert-Equal    "propagates the installer's exit code" 7                $LASTEXITCODE
+
+    # An unreachable URL must fail loudly rather than pretend to install.
+    $env:CLAUDE_CARBON_INSTALL_URL = 'http://127.0.0.1:8791/missing.sh'
+    $missOut = & powershell -NoProfile -ExecutionPolicy Bypass -File $InstallPs1 2>&1 | Out-String
+    Assert-Contains "reports a download failure"     "could not download"   $missOut
+    Assert-Equal    "non-zero exit on download failure" $true               ($LASTEXITCODE -ne 0)
+}
+finally {
+    Remove-Item Env:\CLAUDE_CARBON_INSTALL_URL -ErrorAction SilentlyContinue
+    if ($server -and -not $server.HasExited) { Stop-Process -Id $server.Id -Force -ErrorAction SilentlyContinue }
+    Remove-Item -LiteralPath $tempRoot -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+Write-Host ""
+Write-Host "-----------------------------"
+Write-Host "passed: $($script:Passed)   failed: $($script:Failed)"
+if ($script:Failed -gt 0) { exit 1 }
+Write-Host "All $($script:Passed) install.ps1 assertions passed."

--- a/tests/run-install-tests.sh
+++ b/tests/run-install-tests.sh
@@ -42,7 +42,20 @@ PASSED=0
 FAILED=0
 
 ok() {   PASSED=$((PASSED + 1)); echo "PASS $1"; }
-bad() {  FAILED=$((FAILED + 1)); echo "FAIL $1"; echo "       expected: $2"; echo "       actual:   $3"; }
+bad() {
+  FAILED=$((FAILED + 1))
+  echo "FAIL $1"
+  echo "       expected: $2"
+  echo "       actual:   $3"
+  # Two strings that render identically differ by something invisible: a carriage
+  # return from a Windows tool, a trailing space, a non-ASCII lookalike. Printing
+  # the bytes turns "expected X, got X" into an actionable failure.
+  if [ "${#2}" = "${#3}" ] || [ "$2" = "$3 " ] || [ "$2 " = "$3" ]; then
+    echo "       (same rendering, ${#2} vs ${#3} chars; bytes below)"
+    printf '       expected: '; printf '%s' "$2" | od -An -c | tr -s ' ' | tr -d '\n'; echo
+    printf '       actual:   '; printf '%s' "$3" | od -An -c | tr -s ' ' | tr -d '\n'; echo
+  fi
+}
 
 # check <name> <expected> <actual>
 check() {

--- a/tests/run-install-tests.sh
+++ b/tests/run-install-tests.sh
@@ -47,14 +47,12 @@ bad() {
   echo "FAIL $1"
   echo "       expected: $2"
   echo "       actual:   $3"
-  # Two strings that render identically differ by something invisible: a carriage
-  # return from a Windows tool, a trailing space, a non-ASCII lookalike. Printing
-  # the bytes turns "expected X, got X" into an actionable failure.
-  if [ "${#2}" = "${#3}" ] || [ "$2" = "$3 " ] || [ "$2 " = "$3" ]; then
-    echo "       (same rendering, ${#2} vs ${#3} chars; bytes below)"
-    printf '       expected: '; printf '%s' "$2" | od -An -c | tr -s ' ' | tr -d '\n'; echo
-    printf '       actual:   '; printf '%s' "$3" | od -An -c | tr -s ' ' | tr -d '\n'; echo
-  fi
+  # Always dump the bytes. A carriage return from a Windows tool, a trailing space or
+  # a stray separator renders as nothing in a CI log, turning a failure into "expected
+  # X, got X" with no way to act on it.
+  echo "       (${#2} vs ${#3} chars)"
+  printf '       expected bytes: '; printf '%s' "$2" | od -An -c | tr -s ' ' | tr -d '\n'; echo
+  printf '       actual bytes:   '; printf '%s' "$3" | od -An -c | tr -s ' ' | tr -d '\n'; echo
 }
 
 # check <name> <expected> <actual>

--- a/tests/run-install-tests.sh
+++ b/tests/run-install-tests.sh
@@ -19,7 +19,11 @@ command -v jq  >/dev/null 2>&1 || { echo "FAIL: jq is required" >&2; exit 1; }
 command -v git >/dev/null 2>&1 || { echo "FAIL: git is required" >&2; exit 1; }
 [ -f "$CONFIGURE" ] || { echo "FAIL: missing $CONFIGURE" >&2; exit 1; }
 
-TMPROOT="$(mktemp -d "${TMPDIR:-/tmp}/claude-carbon-tests.XXXXXX")"
+# cc_tmpdir rather than $TMPDIR directly: under Git Bash on Windows TMPDIR can
+# hold a native "C:\Users\..." path, which mktemp cannot use as a template.
+# shellcheck source=scripts/portable-lib.sh
+. "${REPO_DIR}/scripts/portable-lib.sh"
+TMPROOT="$(mktemp -d "$(cc_tmpdir)/claude-carbon-tests.XXXXXX")"
 # Normalize: $TMPDIR often carries a trailing slash, and the scripts under test resolve their
 # own paths with `cd && pwd`, so an unnormalized root makes assertions compare //-doubled
 # strings against clean ones.

--- a/tests/run-install-tests.sh
+++ b/tests/run-install-tests.sh
@@ -60,8 +60,10 @@ check() {
   if [ "$2" = "$3" ]; then ok "$1"; else bad "$1" "$2" "$3"; fi
 }
 
-# Commands registered for a hook event, newline-separated, in order.
-hook_commands() { jq -r --arg e "$2" '[.hooks[$e][]?.hooks[]?.command] | .[]' "$1" 2>/dev/null; }
+# Commands registered for a hook event, newline-separated, in order. The tr strips the
+# interior carriage returns Git Bash leaves in a multi-line command substitution; the
+# assertions are about the commands, not about how the capture was framed.
+hook_commands() { jq -r --arg e "$2" '[.hooks[$e][]?.hooks[]?.command] | .[]' "$1" 2>/dev/null | tr -d '\r'; }
 hook_count()    { jq -r --arg e "$2" '[.hooks[$e][]?.hooks[]?.command] | length' "$1" 2>/dev/null; }
 
 # What configure-settings.sh writes is platform-dependent by design. On Windows it

--- a/tests/run-install-tests.sh
+++ b/tests/run-install-tests.sh
@@ -53,9 +53,15 @@ check() {
 hook_commands() { jq -r --arg e "$2" '[.hooks[$e][]?.hooks[]?.command] | .[]' "$1" 2>/dev/null; }
 hook_count()    { jq -r --arg e "$2" '[.hooks[$e][]?.hooks[]?.command] | length' "$1" 2>/dev/null; }
 
-STATUSLINE="${REPO_DIR}/scripts/statusline.sh"
-STOP="${REPO_DIR}/scripts/persist-session.sh"
-RESCAN="${REPO_DIR}/scripts/safety-rescan.sh"
+# What configure-settings.sh writes is platform-dependent by design. On Windows it
+# writes the "mixed" spelling ("D:/a/repo/scripts/x.sh"): Claude Code may resolve the
+# path with Windows APIs before spawning Git Bash, and its status line docs require
+# forward slashes because Git Bash eats unquoted backslashes. cc_native_path is the
+# identity function on macOS and Linux, so these expectations are unchanged there.
+CMD_BASE="$(cc_native_path "$REPO_DIR")"
+STATUSLINE="${CMD_BASE}/scripts/statusline.sh"
+STOP="${CMD_BASE}/scripts/persist-session.sh"
+RESCAN="${CMD_BASE}/scripts/safety-rescan.sh"
 
 # ---------------------------------------------------------------- 1. cold start
 
@@ -69,11 +75,18 @@ check "cold start: statusLine"             "$STATUSLINE" "$(jq -r '.statusLine.c
 check "cold start: Stop hook"              "$STOP"       "$(hook_commands "$S" Stop)"
 check "cold start: SessionStart hook"      "$RESCAN"     "$(hook_commands "$S" SessionStart)"
 
+# Symlinked everywhere a symlink works. Git Bash cannot create one without Windows
+# Developer Mode, so there the commands are copied on purpose and configure-settings.sh
+# refreshes the copy on update; assert whichever form this platform is meant to produce.
 MISSING=""
 for c in carbon-report carbon-card carbon-update carbon-badge carbon-pr; do
-  [ -L "${CFG}/commands/${c}.md" ] || MISSING="${MISSING}${c} "
+  if cc_is_windows; then
+    cmp -s "${REPO_DIR}/skills/${c}/SKILL.md" "${CFG}/commands/${c}.md" 2>/dev/null || MISSING="${MISSING}${c} "
+  else
+    [ -L "${CFG}/commands/${c}.md" ] || MISSING="${MISSING}${c} "
+  fi
 done
-check "cold start: /carbon-* commands linked" "" "$MISSING"
+check "cold start: /carbon-* commands installed" "" "$MISSING"
 
 # ---------------------------------------------------------------- 2. pre-1.1.3 install repaired
 

--- a/tests/run-portability-tests.sh
+++ b/tests/run-portability-tests.sh
@@ -78,6 +78,11 @@ is "below the tonne tier"      "no"  "$(ge 9999999.5 10000000)"
 is "zero against zero"         "yes" "$(ge 0 0)"
 is "fraction below one"        "no"  "$(ge 0.5 1)"
 is "large float"               "yes" "$(ge 123456.789 1000)"
+# sqlite3 renders a large REAL in scientific notation, so a total can reach the
+# formatter spelled "1e3". awk parses that; bc rejects it with a syntax error, which
+# is one more reason the comparison moved off bc rather than a regression from it.
+is "scientific notation"       "yes" "$(ge 1e3 1000)"
+is "scientific notation below" "no"  "$(ge 1e2 1000)"
 
 # Cross-check against bc itself wherever bc still exists, so the replacement is
 # provably equivalent on the machines that can prove it.
@@ -85,8 +90,10 @@ if command -v bc >/dev/null 2>&1; then
   echo ""
   echo "cc_num_ge vs bc (cross-check)"
   BC_MISMATCH=0
+  # Decimal literals only: bc has no scientific-notation literal and errors on "1e3",
+  # which is asserted separately above.
   for pair in "1000 1000" "999.9 1000" "1000.1 1000" "0 0" "0.5 1" "10000000 10000000" \
-              "9999999.5 10000000" "123456.789 1000" "431.7045 1000" "1e3 1000"; do
+              "9999999.5 10000000" "123456.789 1000" "431.7045 1000"; do
     set -- $pair
     if cc_num_ge "$1" "$2"; then AWK_R=1; else AWK_R=0; fi
     BC_R="$(echo "$1 >= $2" | LC_ALL=C bc -l)"

--- a/tests/run-portability-tests.sh
+++ b/tests/run-portability-tests.sh
@@ -1,0 +1,238 @@
+#!/usr/bin/env bash
+# run-portability-tests.sh — guards the cross-platform contract.
+#
+# claude-carbon runs on macOS, Linux, and native Windows through the Git Bash that
+# Claude Code spawns for hooks and the status line. Almost none of that is testable
+# by running it on one machine, so this suite pins the parts that are: the pure
+# string logic of the path conversion (exercised with the platform forced), the
+# absence of dependencies Git for Windows does not ship, and the two places where
+# the same logic is written twice and could silently drift apart.
+#
+# Runs on every platform. Dependencies: bash, awk.
+set -uo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PASS=0
+FAIL=0
+
+ok()   { PASS=$((PASS + 1)); printf '  ok   %s\n' "$1"; }
+bad()  { FAIL=$((FAIL + 1)); printf '  FAIL %s\n' "$1"; [ $# -gt 1 ] && printf '       %s\n' "$2"; }
+is()   { # is <label> <expected> <actual>
+  if [ "$2" = "$3" ]; then ok "$1"; else bad "$1" "expected '$2', got '$3'"; fi
+}
+
+echo "portability tests"
+echo "─────────────────────────────"
+
+# ── 1. cc_path: the Windows string rewrite ───────────────────────────────────
+# Sourced in a subshell with the platform forced to Windows and cygpath disabled,
+# which is the branch a macOS or Linux runner can actually execute. The cygpath
+# branch is covered by the Windows CI job, where cygpath is real.
+echo ""
+echo "cc_path (platform forced to windows, no cygpath)"
+
+winpath() (
+  # shellcheck source=scripts/portable-lib.sh
+  . "${REPO_DIR}/scripts/portable-lib.sh"
+  CC_OS="windows"
+  CC_CYGPATH=""
+  cc_path "$1"
+)
+
+is "backslash drive path"      "/c/Users/me/x.jsonl" "$(winpath 'C:\Users\me\x.jsonl')"
+is "lowercase drive letter"    "/d/tmp/a"            "$(winpath 'd:\tmp\a')"
+is "forward-slash drive path"  "/e/proj"             "$(winpath 'E:/proj')"
+is "mixed separators"          "/c/Users/me/a/b"     "$(winpath 'C:\Users\me/a\b')"
+is "already POSIX"             "/c/Users/me"         "$(winpath '/c/Users/me')"
+is "relative path untouched"   "scripts/x.sh"        "$(winpath 'scripts/x.sh')"
+is "empty stays empty"         ""                    "$(winpath '')"
+is "path with a space"         "/c/Program Files/Git" "$(winpath 'C:\Program Files\Git')"
+
+# On macOS and Linux cc_path must be the identity function, including for a string
+# that merely looks like a Windows path — a file really named "C:\x" on a Mac.
+posixpath() (
+  # shellcheck source=scripts/portable-lib.sh
+  . "${REPO_DIR}/scripts/portable-lib.sh"
+  CC_OS="linux"
+  cc_path "$1"
+)
+echo ""
+echo "cc_path (platform forced to linux)"
+is "identity on POSIX path"    "/home/me/.claude"    "$(posixpath '/home/me/.claude')"
+is "identity on odd filename"  'C:\weird'            "$(posixpath 'C:\weird')"
+
+# ── 2. cc_num_ge: the bc replacement ─────────────────────────────────────────
+# bc is absent from Git for Windows, so every float comparison moved to awk. These
+# are the exact thresholds format_co2 and the projection tier depend on.
+echo ""
+echo "cc_num_ge (awk float comparison)"
+# shellcheck source=scripts/portable-lib.sh
+. "${REPO_DIR}/scripts/portable-lib.sh"
+
+ge() { if cc_num_ge "$1" "$2"; then echo yes; else echo no; fi; }
+is "equal values"              "yes" "$(ge 1000 1000)"
+is "just below the tier"       "no"  "$(ge 999.9 1000)"
+is "just above the tier"       "yes" "$(ge 1000.1 1000)"
+is "tonne tier boundary"       "yes" "$(ge 10000000 10000000)"
+is "below the tonne tier"      "no"  "$(ge 9999999.5 10000000)"
+is "zero against zero"         "yes" "$(ge 0 0)"
+is "fraction below one"        "no"  "$(ge 0.5 1)"
+is "large float"               "yes" "$(ge 123456.789 1000)"
+
+# Cross-check against bc itself wherever bc still exists, so the replacement is
+# provably equivalent on the machines that can prove it.
+if command -v bc >/dev/null 2>&1; then
+  echo ""
+  echo "cc_num_ge vs bc (cross-check)"
+  BC_MISMATCH=0
+  for pair in "1000 1000" "999.9 1000" "1000.1 1000" "0 0" "0.5 1" "10000000 10000000" \
+              "9999999.5 10000000" "123456.789 1000" "431.7045 1000" "1e3 1000"; do
+    set -- $pair
+    if cc_num_ge "$1" "$2"; then AWK_R=1; else AWK_R=0; fi
+    BC_R="$(echo "$1 >= $2" | LC_ALL=C bc -l)"
+    [ "$AWK_R" = "$BC_R" ] || { BC_MISMATCH=1; bad "bc parity for '$1 >= $2'" "awk=$AWK_R bc=$BC_R"; }
+  done
+  [ "$BC_MISMATCH" = "0" ] && ok "agrees with bc on all sampled comparisons"
+fi
+
+# ── 3. install.sh's inline fallback must not drift ───────────────────────────
+# The installer is curl-piped with no clone on disk, so it carries its own copy of
+# cc_path and cc_install_hint. Extract that copy and diff its behaviour against the
+# real library on every input both are expected to handle.
+echo ""
+echo "install.sh fallback agrees with scripts/portable-lib.sh"
+
+FALLBACK="$(awk '/# >>> portable-lib fallback/{f=1;next} /# <<< portable-lib fallback/{f=0} f' "${REPO_DIR}/install.sh")"
+if [ -z "$FALLBACK" ]; then
+  bad "fallback block found in install.sh" "markers missing or empty"
+else
+  ok "fallback block found in install.sh"
+
+  DRIFT=0
+  for OS in darwin linux windows; do
+    for CMD in jq sqlite3 git node curl; do
+      LIB_OUT="$(
+        # shellcheck source=scripts/portable-lib.sh
+        . "${REPO_DIR}/scripts/portable-lib.sh"
+        CC_OS="$OS"
+        cc_install_hint "$CMD"
+      )"
+      FB_OUT="$(eval "$FALLBACK"; CC_OS="$OS"; cc_install_hint "$CMD")"
+      if [ "$LIB_OUT" != "$FB_OUT" ]; then
+        DRIFT=1
+        bad "install hint for $CMD on $OS" "lib='$LIB_OUT' fallback='$FB_OUT'"
+      fi
+    done
+  done
+  [ "$DRIFT" = "0" ] && ok "install hints identical for 5 commands x 3 platforms"
+
+  DRIFT=0
+  for P in 'C:\Users\me\x.jsonl' 'd:\tmp\a' 'E:/proj' '/c/Users/me' 'scripts/x.sh' 'C:\Program Files\Git'; do
+    # Neither side has cygpath forced: on macOS and Linux both take the string
+    # rewrite, on the Windows runner both take cygpath. Either way they must agree.
+    LIB_OUT="$(
+      # shellcheck source=scripts/portable-lib.sh
+      . "${REPO_DIR}/scripts/portable-lib.sh"
+      CC_OS="windows"
+      cc_path "$P"
+    )"
+    FB_OUT="$(eval "$FALLBACK"; CC_OS="windows"; cc_path "$P")"
+    if [ "$LIB_OUT" != "$FB_OUT" ]; then
+      DRIFT=1
+      bad "cc_path for '$P'" "lib='$LIB_OUT' fallback='$FB_OUT'"
+    fi
+  done
+  [ "$DRIFT" = "0" ] && ok "cc_path identical on 6 sample paths"
+fi
+
+# ── 4. Dependencies Git for Windows does not ship ────────────────────────────
+# Anything reachable from a Windows user's machine must stay within bash, awk, sed,
+# grep, date, curl, git (shipped with Git for Windows) plus jq and sqlite3 (the two
+# documented prerequisites) and node (only for the PNG cards, which need Playwright
+# anyway). bc and python3 were dependencies before Windows support and must not come back.
+echo ""
+echo "no reintroduced non-Windows dependencies"
+
+RUNTIME_FILES=""
+for f in "${REPO_DIR}"/scripts/*.sh "${REPO_DIR}/install.sh" "${REPO_DIR}"/skills/*/SKILL.md; do
+  case "$f" in
+    */release.sh|*/check-versions.sh|*/traffic-snapshot.sh) continue ;;  # maintainer tooling, never runs on a user machine
+  esac
+  RUNTIME_FILES="$RUNTIME_FILES $f"
+done
+
+# shellcheck disable=SC2086
+BAD_BC="$(grep -nE '(^|[^[:alnum:]_./-])bc[[:space:]]+-l|\|[[:space:]]*bc([[:space:]]|$)' $RUNTIME_FILES 2>/dev/null || true)"
+if [ -z "$BAD_BC" ]; then ok "no bc invocation"; else bad "no bc invocation" "$BAD_BC"; fi
+
+# shellcheck disable=SC2086
+BAD_PY="$(grep -nE '(^|[^[:alnum:]_./-])python3?[[:space:]]' $RUNTIME_FILES 2>/dev/null | grep -v '^[^:]*:[0-9]*:[[:space:]]*#' || true)"
+if [ -z "$BAD_PY" ]; then ok "no python invocation"; else bad "no python invocation" "$BAD_PY"; fi
+
+# shellcheck disable=SC2086
+BAD_TMP="$(grep -nE '(^|[^[:alnum:]_$"{/-])/tmp/' $RUNTIME_FILES 2>/dev/null | grep -v '^[^:]*:[0-9]*:[[:space:]]*#' || true)"
+if [ -z "$BAD_TMP" ]; then ok "no hardcoded /tmp path"; else bad "no hardcoded /tmp path" "$BAD_TMP"; fi
+
+# ── 5. Line endings ──────────────────────────────────────────────────────────
+# Git for Windows clones with core.autocrlf=true, which would rewrite every script
+# to CRLF and make bash choke on the carriage returns. .gitattributes pins them.
+echo ""
+echo "line endings"
+
+if [ -f "${REPO_DIR}/.gitattributes" ] && grep -qE '^\*\.sh[[:space:]]+text[[:space:]]+eol=lf' "${REPO_DIR}/.gitattributes"; then
+  ok ".gitattributes pins *.sh to LF"
+else
+  bad ".gitattributes pins *.sh to LF" "missing '*.sh text eol=lf'"
+fi
+
+CRLF_FILES=""
+for f in "${REPO_DIR}"/scripts/*.sh "${REPO_DIR}"/tests/*.sh "${REPO_DIR}/install.sh"; do
+  if LC_ALL=C grep -qU $'\r' "$f" 2>/dev/null; then CRLF_FILES="${CRLF_FILES} $(basename "$f")"; fi
+done
+if [ -z "$CRLF_FILES" ]; then ok "no CRLF in tracked shell scripts"; else bad "no CRLF in tracked shell scripts" "$CRLF_FILES"; fi
+
+# ── 6. Hook and status-line wiring ───────────────────────────────────────────
+# Claude Code runs these through a shell (sh -c, or Git Bash on Windows). The docs
+# require each path placeholder to be double-quoted there: unquoted, a Windows
+# CLAUDE_PLUGIN_ROOT loses its backslashes and the hook fails with no visible error.
+echo ""
+echo "plugin wiring quotes its path placeholders"
+
+for spec in ".claude-plugin/plugin.json" "hooks/hooks.json"; do
+  UNQUOTED="$(grep -n '"command": "\${CLAUDE_PLUGIN_ROOT}' "${REPO_DIR}/${spec}" 2>/dev/null || true)"
+  if [ -z "$UNQUOTED" ]; then ok "${spec}: placeholders quoted"; else bad "${spec}: placeholders quoted" "$UNQUOTED"; fi
+done
+
+# ── 7. Everything still parses ───────────────────────────────────────────────
+echo ""
+echo "syntax"
+
+SYNTAX_BAD=""
+for f in "${REPO_DIR}"/scripts/*.sh "${REPO_DIR}"/tests/*.sh "${REPO_DIR}/install.sh"; do
+  bash -n "$f" 2>/dev/null || SYNTAX_BAD="${SYNTAX_BAD} $(basename "$f")"
+done
+if [ -z "$SYNTAX_BAD" ]; then ok "all shell scripts parse"; else bad "all shell scripts parse" "$SYNTAX_BAD"; fi
+
+# The skills carry their own inline bash, which no shell ever syntax-checks in
+# normal use: a typo there only surfaces when a user runs the slash command.
+SKILL_BAD=""
+SKILL_TMP="$(mktemp)"
+for f in "${REPO_DIR}"/skills/*/SKILL.md; do
+  awk '/^```bash$/{inb=1;next} /^```$/{inb=0} inb' "$f" > "$SKILL_TMP"
+  bash -n "$SKILL_TMP" 2>/dev/null || SKILL_BAD="${SKILL_BAD} $(basename "$(dirname "$f")")"
+done
+rm -f "$SKILL_TMP"
+if [ -z "$SKILL_BAD" ]; then ok "all SKILL.md bash blocks parse"; else bad "all SKILL.md bash blocks parse" "$SKILL_BAD"; fi
+
+# Every skill must carry the path helper: they resolve CLAUDE_* variables before
+# any library is reachable, so each one needs its own copy.
+HELPER_BAD=""
+for f in "${REPO_DIR}"/skills/*/SKILL.md; do
+  grep -q 'ccp() {' "$f" || HELPER_BAD="${HELPER_BAD} $(basename "$(dirname "$f")")"
+done
+if [ -z "$HELPER_BAD" ]; then ok "all skills define the ccp path helper"; else bad "all skills define the ccp path helper" "$HELPER_BAD"; fi
+
+echo ""
+echo "─────────────────────────────"
+echo "passed: ${PASS}   failed: ${FAIL}"
+[ "$FAIL" -eq 0 ] || exit 1

--- a/tests/run-pr-tests.sh
+++ b/tests/run-pr-tests.sh
@@ -10,7 +10,7 @@
 # a scratch git repo); the real ~/.claude is never read or written.
 #
 # bash 3.2 compatible (macOS default): no associative arrays, no mapfile.
-# Dependencies: sqlite3, jq, bc, git.
+# Dependencies: sqlite3, jq, awk, git.
 
 set -u
 
@@ -19,12 +19,16 @@ REPO_DIR="$(dirname "$SCRIPT_DIR")"
 PR_SCRIPT="${REPO_DIR}/scripts/generate-pr-report.sh"
 PERSIST="${REPO_DIR}/scripts/persist-session.sh"
 
-for c in sqlite3 jq bc git; do
+for c in sqlite3 jq awk git; do
   command -v "$c" >/dev/null 2>&1 || { echo "FAIL: $c is required" >&2; exit 1; }
 done
 [ -f "$PR_SCRIPT" ] || { echo "FAIL: missing $PR_SCRIPT" >&2; exit 1; }
 
-TMPROOT="$(mktemp -d "${TMPDIR:-/tmp}/claude-carbon-pr-tests.XXXXXX")"
+# cc_tmpdir rather than $TMPDIR directly: under Git Bash on Windows TMPDIR can
+# hold a native "C:\Users\..." path, which mktemp cannot use as a template.
+# shellcheck source=scripts/portable-lib.sh
+. "${REPO_DIR}/scripts/portable-lib.sh"
+TMPROOT="$(mktemp -d "$(cc_tmpdir)/claude-carbon-pr-tests.XXXXXX")"
 TMPROOT="$(cd "$TMPROOT" && pwd -P)"
 
 # Only ever delete a path we just created under a temp root, never an arbitrary variable.

--- a/tests/run-windows-e2e.sh
+++ b/tests/run-windows-e2e.sh
@@ -1,0 +1,251 @@
+#!/usr/bin/env bash
+# run-windows-e2e.sh — the assertions that only a real Windows machine can make.
+#
+# tests/run-portability-tests.sh pins the pure string logic, which any platform can
+# check by forcing CC_OS. What it cannot reach is the part that made Windows fail in
+# the first place: a real cygpath, a real native path pointing at a real file, and the
+# way Claude Code actually spawns a hook. This suite covers exactly that, and skips
+# with exit 0 everywhere else so it can sit in the normal CI matrix.
+#
+# Every case runs under its own throwaway CLAUDE_CONFIG_DIR; the real ~/.claude is
+# never read or written. No network.
+#
+# bash 3.2 compatible. Dependencies: jq, sqlite3, git, cygpath (Git for Windows).
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(dirname "$SCRIPT_DIR")"
+
+# shellcheck source=scripts/portable-lib.sh
+. "${REPO_DIR}/scripts/portable-lib.sh"
+
+if ! cc_is_windows; then
+  echo "SKIP run-windows-e2e.sh: not running under Git Bash / MSYS (CC_OS=${CC_OS})."
+  echo "     These assertions need a real Windows filesystem; CI runs them on windows-latest."
+  exit 0
+fi
+
+for c in jq sqlite3 git cygpath; do
+  command -v "$c" >/dev/null 2>&1 || { echo "FAIL: $c is required" >&2; exit 1; }
+done
+
+TMPROOT="$(mktemp -d "$(cc_tmpdir)/claude-carbon-win-e2e.XXXXXX")"
+TMPROOT="$(cd "$TMPROOT" && pwd -P)"
+
+cleanup() {
+  case "$TMPROOT" in
+    */claude-carbon-win-e2e.*) rm -rf "$TMPROOT" ;;
+    *) echo "refusing to clean unexpected path: $TMPROOT" >&2 ;;
+  esac
+}
+trap cleanup EXIT
+
+PASSED=0
+FAILED=0
+ok()  { PASSED=$((PASSED + 1)); echo "PASS $1"; }
+bad() { FAILED=$((FAILED + 1)); echo "FAIL $1"; echo "       expected: $2"; echo "       actual:   $3"; }
+check() { if [ "$2" = "$3" ]; then ok "$1"; else bad "$1" "$2" "$3"; fi; }
+# contains <name> <needle> <haystack>
+contains() {
+  case "$3" in *"$2"*) ok "$1" ;; *) bad "$1" "to contain '$2'" "$3" ;; esac
+}
+
+echo "windows end-to-end (CC_OS=${CC_OS}, cygpath=$(command -v cygpath))"
+echo "─────────────────────────────"
+
+# ── 1. cc_path against the real filesystem ───────────────────────────────────
+# Not a string comparison this time: convert a file's own native path back and
+# assert bash can actually open the result.
+echo ""
+echo "cc_path round-trip on a real file"
+
+PROBE_DIR="${TMPROOT}/probe dir"        # a space, because Program Files has one
+mkdir -p "$PROBE_DIR"
+PROBE="${PROBE_DIR}/transcript.jsonl"
+echo '{"probe":true}' > "$PROBE"
+
+NATIVE_PROBE="$(cygpath -w "$PROBE")"   # C:\...\probe dir\transcript.jsonl
+contains "cygpath -w produced a native path" "\\" "$NATIVE_PROBE"
+
+CONVERTED="$(cc_path "$NATIVE_PROBE")"
+check "converted path is readable"      "yes" "$([ -f "$CONVERTED" ] && echo yes || echo no)"
+check "converted path reads the file"   '{"probe":true}' "$(cat "$CONVERTED" 2>/dev/null)"
+check "already-POSIX path unchanged"    "$PROBE" "$(cc_path "$PROBE")"
+
+# The mixed spelling is what goes back into settings.json: bash must open it too.
+MIXED="$(cc_native_path "$PROBE")"
+contains "cc_native_path uses forward slashes" "/" "$MIXED"
+case "$MIXED" in
+  *\\*) bad "cc_native_path has no backslash" "no backslash" "$MIXED" ;;
+  *)    ok  "cc_native_path has no backslash" ;;
+esac
+check "mixed path is readable by bash"  "yes" "$([ -f "$MIXED" ] && echo yes || echo no)"
+
+# ── 2. The Stop hook fed a native transcript path ────────────────────────────
+# This is the failure the whole port exists for: Claude Code hands the hook
+# "C:\Users\...\x.jsonl" and bash cannot open it.
+echo ""
+echo "Stop hook with a native transcript_path"
+
+export CLAUDE_CONFIG_DIR="${TMPROOT}/config"
+DB_PATH="${CLAUDE_CONFIG_DIR}/claude-carbon/carbon.db"
+mkdir -p "${CLAUDE_CONFIG_DIR}/claude-carbon"
+
+sqlite3 "$DB_PATH" "CREATE TABLE sessions (session_id TEXT PRIMARY KEY, project TEXT, model TEXT, input_tokens INTEGER, output_tokens INTEGER, cache_read_tokens INTEGER DEFAULT 0, cache_creation_tokens INTEGER DEFAULT 0, cache_creation_1h_tokens INTEGER DEFAULT 0, cost_usd REAL, co2_grams REAL, started_at TEXT, ended_at TEXT, source TEXT DEFAULT 'live', methodology_version INTEGER DEFAULT 1, excluded INTEGER DEFAULT 0, git_branch TEXT DEFAULT '');"
+
+PROJ="${TMPROOT}/myproj"
+mkdir -p "$PROJ"
+git -C "$PROJ" init -q -b main 2>/dev/null || { git -C "$PROJ" init -q; git -C "$PROJ" checkout -q -b main; }
+
+SESSION="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+TRANSCRIPT="${TMPROOT}/session.jsonl"
+cat > "$TRANSCRIPT" <<EOF
+{"type":"user","cwd":"${PROJ}","gitBranch":"main","sessionId":"${SESSION}","message":{"role":"user","content":"go"}}
+{"type":"assistant","cwd":"${PROJ}","gitBranch":"main","requestId":"req_1","message":{"id":"msg_1","model":"claude-opus-5","usage":{"input_tokens":10000,"cache_creation_input_tokens":20000,"cache_read_input_tokens":100000,"output_tokens":5000}}}
+EOF
+
+# Exactly the spelling Claude Code uses: native, backslash-separated, both fields.
+NATIVE_TRANSCRIPT="$(cygpath -w "$TRANSCRIPT")"
+NATIVE_CWD="$(cygpath -w "$PROJ")"
+
+jq -n --arg s "$SESSION" --arg t "$NATIVE_TRANSCRIPT" --arg c "$NATIVE_CWD" \
+  '{session_id: $s, transcript_path: $t, cwd: $c}' \
+  | bash "${REPO_DIR}/scripts/persist-session.sh"
+
+ROW="$(sqlite3 "$DB_PATH" "SELECT COUNT(*) FROM sessions WHERE session_id='${SESSION}';")"
+check "row persisted from a native path" "1" "$ROW"
+check "output tokens captured"           "5000"   "$(sqlite3 "$DB_PATH" "SELECT output_tokens FROM sessions WHERE session_id='${SESSION}';")"
+check "cache reads captured"             "100000" "$(sqlite3 "$DB_PATH" "SELECT cache_read_tokens FROM sessions WHERE session_id='${SESSION}';")"
+check "project derived from native cwd"  "myproj" "$(sqlite3 "$DB_PATH" "SELECT project FROM sessions WHERE session_id='${SESSION}';")"
+check "branch captured"                  "main"   "$(sqlite3 "$DB_PATH" "SELECT git_branch FROM sessions WHERE session_id='${SESSION}';")"
+
+CO2="$(sqlite3 "$DB_PATH" "SELECT CAST(co2_grams AS INT) > 0 FROM sessions WHERE session_id='${SESSION}';")"
+check "CO2 computed"                     "1" "$CO2"
+
+# ── 3. The status line fed a native current_dir ──────────────────────────────
+echo ""
+echo "status line with a native workspace.current_dir"
+
+SL_OUT="$(jq -n --arg s "$SESSION" --arg d "$NATIVE_CWD" \
+  '{session_id: $s, model: {id: "claude-opus-5", display_name: "Opus 5"},
+    context_window: {total_input_tokens: 10000, total_output_tokens: 5000, used_percentage: 20},
+    cost: {total_cost_usd: 1.5}, workspace: {current_dir: $d}}' \
+  | bash "${REPO_DIR}/scripts/statusline.sh")"
+
+contains "project name resolved"  "myproj"  "$SL_OUT"
+contains "cost rendered"          "\$1.50"  "$SL_OUT"
+contains "CO2 rendered"           "CO₂"     "$SL_OUT"
+# The DB row exists, so the status line must report the stored session total rather
+# than the context-window fallback. Anything under a gram would mean it fell back.
+case "$SL_OUT" in
+  *" 0g CO₂"*) bad "status line read the stored row" "a non-zero total" "$SL_OUT" ;;
+  *)           ok  "status line read the stored row" ;;
+esac
+
+# ── 4. Hook wiring the way Claude Code spawns it ─────────────────────────────
+# Shell form: Claude Code substitutes the placeholder into the command string and
+# hands the whole string to Git Bash. Reproduce that with a native plugin root,
+# which is what broke before the manifests quoted the placeholder.
+echo ""
+echo "hook manifests spawn correctly from a native CLAUDE_PLUGIN_ROOT"
+
+NATIVE_ROOT="$(cygpath -w "$REPO_DIR")"
+
+spawn_like_claude_code() { # spawn_like_claude_code <command template>
+  local template="$1" resolved
+  resolved="${template//\$\{CLAUDE_PLUGIN_ROOT\}/$NATIVE_ROOT}"
+  CLAUDE_PLUGIN_ROOT="$NATIVE_ROOT" bash -c "$resolved" 2>&1
+}
+
+STOP_TEMPLATE="$(jq -r '.hooks.Stop[0].hooks[0].command' "${REPO_DIR}/hooks/hooks.json")"
+START_TEMPLATE="$(jq -r '.hooks.SessionStart[0].hooks[0].command' "${REPO_DIR}/hooks/hooks.json")"
+SL_TEMPLATE="$(jq -r '.statusLine.command' "${REPO_DIR}/.claude-plugin/plugin.json")"
+
+# The Stop hook is silent by contract, so "found and ran" means no shell error.
+STOP_ERR="$(printf '{}' | spawn_like_claude_code "$STOP_TEMPLATE")"
+case "$STOP_ERR" in
+  *"No such file"*|*"command not found"*|*"cannot execute"*)
+    bad "Stop hook found from a native plugin root" "no shell error" "$STOP_ERR" ;;
+  *) ok "Stop hook found from a native plugin root" ;;
+esac
+
+START_ERR="$(printf '{}' | spawn_like_claude_code "$START_TEMPLATE")"
+case "$START_ERR" in
+  *"No such file"*|*"command not found"*|*"cannot execute"*)
+    bad "SessionStart hook found from a native plugin root" "no shell error" "$START_ERR" ;;
+  *) ok "SessionStart hook found from a native plugin root" ;;
+esac
+
+SL_SPAWNED="$(jq -n --arg d "$NATIVE_CWD" \
+  '{session_id: "none", model: {id: "claude-sonnet-5", display_name: "Sonnet 5"},
+    context_window: {total_input_tokens: 1000, total_output_tokens: 100, used_percentage: 5},
+    cost: {total_cost_usd: 0.25}, workspace: {current_dir: $d}}' \
+  | spawn_like_claude_code "$SL_TEMPLATE")"
+contains "status line runs from a native plugin root" "CO₂" "$SL_SPAWNED"
+
+# ── 5. What configure-settings.sh writes back ────────────────────────────────
+echo ""
+echo "settings.json wiring"
+
+export CLAUDE_CONFIG_DIR="${TMPROOT}/config2"
+mkdir -p "$CLAUDE_CONFIG_DIR"
+bash "${REPO_DIR}/scripts/configure-settings.sh" >/dev/null 2>&1
+
+SETTINGS="${CLAUDE_CONFIG_DIR}/settings.json"
+check "settings.json created" "yes" "$([ -f "$SETTINGS" ] && echo yes || echo no)"
+
+WRITTEN_SL="$(jq -r '.statusLine.command // ""' "$SETTINGS" 2>/dev/null)"
+# Claude Code's status line docs: a backslash in the command string is eaten by Git
+# Bash and the command fails with no visible error. Forward slashes only.
+case "$WRITTEN_SL" in
+  *\\*) bad "statusLine path has no backslash" "no backslash" "$WRITTEN_SL" ;;
+  *)    ok  "statusLine path has no backslash" ;;
+esac
+check "statusLine path is openable" "yes" "$([ -f "$WRITTEN_SL" ] && echo yes || echo no)"
+
+WRITTEN_STOP="$(jq -r '.hooks.Stop[0].hooks[0].command // ""' "$SETTINGS" 2>/dev/null)"
+check "Stop hook path is openable"  "yes" "$([ -f "$WRITTEN_STOP" ] && echo yes || echo no)"
+
+# Rerunning must not register a second copy of anything, even though the path was
+# written in the mixed spelling and normalize_cmd resolves it through `cd`+`pwd -P`.
+bash "${REPO_DIR}/scripts/configure-settings.sh" >/dev/null 2>&1
+check "idempotent: one Stop hook"        "1" "$(jq '[.hooks.Stop[]?.hooks[]?] | length' "$SETTINGS")"
+check "idempotent: one SessionStart hook" "1" "$(jq '[.hooks.SessionStart[]?.hooks[]?] | length' "$SETTINGS")"
+
+# ── 6. Slash commands: copies, and refreshed on update ───────────────────────
+echo ""
+echo "slash commands are copied and stay current"
+
+CMD="${CLAUDE_CONFIG_DIR}/commands/carbon-report.md"
+check "command installed"      "yes" "$([ -f "$CMD" ] && echo yes || echo no)"
+check "installed as a copy"    "no"  "$([ -L "$CMD" ] && echo yes || echo no)"
+check "content matches source" "yes" "$(cmp -s "${REPO_DIR}/skills/carbon-report/SKILL.md" "$CMD" && echo yes || echo no)"
+
+# Simulate the copy going stale after an update, the way it would if the clone moved
+# forward while the command file stayed behind.
+printf '%s\n' "stale claude-carbon copy" > "$CMD"
+bash "${REPO_DIR}/scripts/configure-settings.sh" >/dev/null 2>&1
+check "stale copy refreshed"   "yes" "$(cmp -s "${REPO_DIR}/skills/carbon-report/SKILL.md" "$CMD" && echo yes || echo no)"
+
+# A command the user wrote themselves carries no claude-carbon marker and must survive.
+USER_CMD="${CLAUDE_CONFIG_DIR}/commands/carbon-badge.md"
+printf '%s\n' "my own command, hands off" > "$USER_CMD"
+bash "${REPO_DIR}/scripts/configure-settings.sh" >/dev/null 2>&1
+check "user-written command untouched" "my own command, hands off" "$(cat "$USER_CMD")"
+
+# ── 7. cc_tmpdir survives a native TMPDIR ────────────────────────────────────
+echo ""
+echo "cc_tmpdir with a native TMPDIR"
+
+NATIVE_TMP="$(cygpath -w "$TMPROOT")"
+RESOLVED="$(TMPDIR="$NATIVE_TMP" bash -c ". '${REPO_DIR}/scripts/portable-lib.sh'; cc_tmpdir")"
+check "native TMPDIR resolves to a usable dir" "yes" "$([ -d "$RESOLVED" ] && echo yes || echo no)"
+check "mktemp works under it" "yes" \
+  "$(f="$(mktemp "${RESOLVED}/cc-probe.XXXXXX" 2>/dev/null)" && [ -f "$f" ] && rm -f "$f" && echo yes || echo no)"
+
+echo ""
+echo "─────────────────────────────"
+echo "passed: ${PASSED}   failed: ${FAILED}"
+[ "$FAILED" -eq 0 ] || exit 1
+echo "All ${PASSED} Windows end-to-end assertions passed."

--- a/tests/run-windows-e2e.sh
+++ b/tests/run-windows-e2e.sh
@@ -213,6 +213,36 @@ bash "${REPO_DIR}/scripts/configure-settings.sh" >/dev/null 2>&1
 check "idempotent: one Stop hook"        "1" "$(jq '[.hooks.Stop[]?.hooks[]?] | length' "$SETTINGS")"
 check "idempotent: one SessionStart hook" "1" "$(jq '[.hooks.SessionStart[]?.hooks[]?] | length' "$SETTINGS")"
 
+# The regression that hid behind a passing idempotence check: when another tool's
+# hook sits AFTER ours in the same event, ours comes back from jq with a trailing
+# carriage return and stops matching itself, so every run appends another copy. Our
+# hook being last is the case that accidentally works, so put a foreign one after it.
+echo ""
+echo "dedupe survives a foreign hook sitting after ours"
+
+CFG3="${TMPROOT}/config3"
+mkdir -p "$CFG3"
+NATIVE_SCRIPTS="$(cc_native_path "${REPO_DIR}/scripts")"
+cat > "${CFG3}/settings.json" <<EOF
+{
+  "hooks": {
+    "SessionStart": [
+      {"matcher": "", "hooks": [{"type": "command", "command": "${NATIVE_SCRIPTS}/safety-rescan.sh"}]},
+      {"matcher": "", "hooks": [{"type": "command", "command": "/opt/other/start.sh"}]}
+    ]
+  }
+}
+EOF
+
+CLAUDE_CONFIG_DIR="$CFG3" bash "${REPO_DIR}/scripts/configure-settings.sh" >/dev/null 2>&1
+CLAUDE_CONFIG_DIR="$CFG3" bash "${REPO_DIR}/scripts/configure-settings.sh" >/dev/null 2>&1
+
+OURS_COUNT="$(jq -r --arg c "${NATIVE_SCRIPTS}/safety-rescan.sh" \
+  '[.hooks.SessionStart[]?.hooks[]?.command | select(. == $c)] | length' "${CFG3}/settings.json")"
+check "our hook not duplicated when it is not last" "1" "$OURS_COUNT"
+check "the foreign hook survives" "1" \
+  "$(jq -r '[.hooks.SessionStart[]?.hooks[]?.command | select(. == "/opt/other/start.sh")] | length' "${CFG3}/settings.json")"
+
 # ── 6. Slash commands: copies, and refreshed on update ───────────────────────
 echo ""
 echo "slash commands are copied and stay current"


### PR DESCRIPTION
Closes #27.

`npx claude-carbon` refused to run on `win32`, and the plugin assumed a POSIX machine everywhere else. It now runs on native Windows through the Git Bash that Claude Code itself spawns for hooks and the status line, falling back to PowerShell only when Git Bash is absent. That is why the plugin stays bash rather than being ported: it speaks the shell its host already uses.

## What was broken

Five failure modes, all silent rather than loud:

| | Fix |
|---|---|
| The JSON piped into the Stop hook and the status line carries `C:\Users\...`, and `${CLAUDE_PLUGIN_ROOT}` expands the same way; bash reads those backslashes as escapes | `scripts/portable-lib.sh` converts on the way in via `cygpath` (string rewrite as fallback); `cc_native_path` does the reverse for paths written back into `settings.json`, which Claude Code may resolve with Windows APIs first |
| `plugin.json` and `hooks.json` passed the placeholder unquoted | Both quote it, as the hooks docs require for shell form. Also fixes a plugin root containing a space on macOS and Linux |
| `core.autocrlf=true` would rewrite every script to CRLF and break bash on `$'\r'` | `.gitattributes` pins `*.sh` and the other parsed files to LF |
| `bc` and `python3` are not shipped by Git for Windows | `bc` becomes `cc_num_ge` (one awk call); `python3` becomes node, already required on that path for Playwright. `jq` and `sqlite3` are the whole remaining Windows prerequisite list |
| Git Bash degrades `ln -s` to a copy without Developer Mode | `configure-settings.sh` copies on purpose and refreshes the copy on update, leaving a user-written command alone |

The five `SKILL.md` files carry their own copy of the path conversion: they resolve `CLAUDE_*` variables before any library is reachable.

## Verification

The node rewrite of the monthly bar chart was checked against `main` by generating all four report pages from a real 226-session database: the HTML is byte-identical. The status line prints the same line on both branches.

Two new suites cover what a POSIX machine cannot:

- `tests/run-windows-e2e.sh` (skips with exit 0 elsewhere): a `cygpath` round-trip on a file whose directory contains a space; the Stop hook fed a native `transcript_path` and asserted to land a row with the right token breakdown, project and branch; the status line fed a native `current_dir`; **the hook manifests spawned the way Claude Code spawns them in shell form**, with the placeholder substituted into the command string and a native `CLAUDE_PLUGIN_ROOT`; `settings.json` asserted free of backslashes, openable, and idempotent on a second run; slash-command copies refreshed when stale while a user-written command survives.
- `tests/run-install-ps1-tests.ps1`: `install.ps1` parses, finds Git Bash, refuses the `System32\bash.exe` WSL launcher, honours `CLAUDE_CODE_GIT_BASH_PATH` and falls through when it points nowhere, normalises a CRLF download, and propagates the installer's exit code. Against a stub served over loopback, so nothing is cloned.

CI gains a `windows-latest` job running the whole suite under Git Bash, plus a `portability` job on Ubuntu. The portability suite also fails if anyone reintroduces `bc`, `python3`, a hardcoded `/tmp`, an unquoted placeholder, or breaks the LF pinning.

## What is still unproven

CI reproduces the shell, not the caller. Two things need a human on Windows:

1. **Claude Code itself.** The spawn is simulated, not executed. If its placeholder substitution differs from the simulation, CI stays green and the plugin breaks.
2. **Console rendering.** The status line emits `🟢`, `▓`, `⌥`, `CO₂`. Windows Terminal handles UTF-8; a console on a legacy codepage does not, and no test catches that.

## Side effects worth noting

- The PNG export server binds `127.0.0.1`, where `python3 -m http.server` defaulted to `0.0.0.0` and briefly published the report pages to the local network.
- The macOS Keychain lookup is now guarded on the platform rather than on the presence of a `security` binary, which could be something else entirely on another OS.