### PR TITLE
fix: two unconverted CLAUDE_* paths, and the guard that could not see them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 ## 2026-09-02
 
+### fix: two CLAUDE_* paths missed by the Windows sweep, and the guard that could not see them
+
+A sweep of every path built from a user-set `CLAUDE_*` variable found two the first
+pass missed. Both fail silently on Windows, which is the whole reason this class of
+bug needs a guard rather than a review.
+
+- `install.sh` built the database path from `CLAUDE_CARBON_DB` without converting it,
+  so a user who set it to a native path got the post-update re-pricing skipped: the
+  `[ -f ]` test simply found nothing and the step was passed over without a word.
+- `generate-report.sh` stamped `last-card-month` under an unconverted
+  `CLAUDE_CONFIG_DIR`, while the status line reads that stamp through the converted
+  one. The card would write where the status line could not look, so the monthly share
+  nudge never cleared.
+
+`tests/run-portability-tests.sh` gains the guard: every `VAR="${CLAUDE_*"` assignment
+in a file that runs on a user's machine must go through the conversion.
+
+Writing that guard exposed a worse problem in the suite itself. The list of runtime
+files was a space-joined string expanded unquoted, so on a checkout under a directory
+whose name contains a space (`~/Claude OS/code/claude-carbon`) it split into filenames
+that do not exist. grep read nothing, and the `bc`, `python3` and `/tmp` guards had
+been reporting "ok" while checking zero files. They are now an array expanded quoted,
+and two positive controls assert the list is real and that grep can read it, because a
+guard that cannot fail is worse than no guard at all.
+
+## 2026-09-02
+
 ### feat: native Windows support (issue #27)
 
 `npx claude-carbon` refused to run on Windows and the plugin assumed a POSIX

--- a/install.sh
+++ b/install.sh
@@ -116,7 +116,7 @@ CLAUDE_CARBON_INSTALLER=1 bash "$INSTALL_DIR/scripts/setup.sh"
 
 # 3b. On update, re-price stored history with the new factors (CO2-only; cost left intact).
 if [ "$WAS_UPDATE" = "1" ]; then
-  DB_PATH="${CLAUDE_CARBON_DB:-${CONFIG_DIR}/claude-carbon/carbon.db}"
+  DB_PATH="$(cc_path "${CLAUDE_CARBON_DB:-${CONFIG_DIR}/claude-carbon/carbon.db}")"
   if [ -f "$DB_PATH" ]; then
     bash "$INSTALL_DIR/scripts/recompute.sh" || echo "  (history not re-priced; see message above)"
   fi

--- a/scripts/generate-report.sh
+++ b/scripts/generate-report.sh
@@ -533,7 +533,7 @@ fi
 echo "Totals since ${SINCE_LABEL_EN}: ${TOTAL_CO2_VALUE} ${TOTAL_CO2_UNIT} CO2e · \$${TOTAL_COST} · ${EQUIV_KM} ${EQUIV_UNIT} by car (${EQUIV_SRC}) · ${TOTAL_SESSIONS} sessions"
 
 # Stamp the month so the statusline's monthly share nudge clears
-STATE_DIR="${CLAUDE_CONFIG_DIR:-${HOME}/.claude}/claude-carbon"
+STATE_DIR="$(cc_path "${CLAUDE_CONFIG_DIR:-${HOME}/.claude}")/claude-carbon"
 mkdir -p "$STATE_DIR" 2>/dev/null || true
 date +%Y-%m > "${STATE_DIR}/last-card-month" 2>/dev/null || true
 

--- a/tests/run-portability-tests.sh
+++ b/tests/run-portability-tests.sh
@@ -160,25 +160,54 @@ fi
 echo ""
 echo "no reintroduced non-Windows dependencies"
 
-RUNTIME_FILES=""
+# An array, expanded quoted. This list used to be a space-joined string expanded
+# unquoted, which split a checkout under a directory with a space in its name (say
+# "~/Claude OS/code/claude-carbon") into filenames that do not exist. grep then read
+# nothing, and every guard below reported "ok" while checking exactly zero files.
+RUNTIME_FILES=()
 for f in "${REPO_DIR}"/scripts/*.sh "${REPO_DIR}/install.sh" "${REPO_DIR}"/skills/*/SKILL.md; do
   case "$f" in
     */release.sh|*/check-versions.sh|*/traffic-snapshot.sh) continue ;;  # maintainer tooling, never runs on a user machine
   esac
-  RUNTIME_FILES="$RUNTIME_FILES $f"
+  [ -f "$f" ] || continue
+  RUNTIME_FILES+=("$f")
 done
 
-# shellcheck disable=SC2086
-BAD_BC="$(grep -nE '(^|[^[:alnum:]_./-])bc[[:space:]]+-l|\|[[:space:]]*bc([[:space:]]|$)' $RUNTIME_FILES 2>/dev/null || true)"
+# Positive control. A guard that cannot fail is worse than no guard, so prove the file
+# list is real and readable before trusting anything the guards below do not find.
+if [ "${#RUNTIME_FILES[@]}" -ge 15 ]; then
+  ok "runtime file list built (${#RUNTIME_FILES[@]} files)"
+else
+  bad "runtime file list built" "expected at least 15 readable files, got ${#RUNTIME_FILES[@]}"
+fi
+CONTROL="$(grep -lE '(^|[^[:alnum:]_./-])jq[[:space:]]' "${RUNTIME_FILES[@]}" 2>/dev/null | wc -l | tr -d ' ')"
+if [ "${CONTROL:-0}" -ge 5 ]; then
+  ok "grep reads the runtime files (jq found in ${CONTROL})"
+else
+  bad "grep reads the runtime files" "expected jq in at least 5 files, found it in ${CONTROL:-0}"
+fi
+
+BAD_BC="$(grep -nE '(^|[^[:alnum:]_./-])bc[[:space:]]+-l|\|[[:space:]]*bc([[:space:]]|$)' "${RUNTIME_FILES[@]}" 2>/dev/null || true)"
 if [ -z "$BAD_BC" ]; then ok "no bc invocation"; else bad "no bc invocation" "$BAD_BC"; fi
 
-# shellcheck disable=SC2086
-BAD_PY="$(grep -nE '(^|[^[:alnum:]_./-])python3?[[:space:]]' $RUNTIME_FILES 2>/dev/null | grep -v '^[^:]*:[0-9]*:[[:space:]]*#' || true)"
+BAD_PY="$(grep -nE '(^|[^[:alnum:]_./-])python3?[[:space:]]' "${RUNTIME_FILES[@]}" 2>/dev/null | grep -v '^[^:]*:[0-9]*:[[:space:]]*#' || true)"
 if [ -z "$BAD_PY" ]; then ok "no python invocation"; else bad "no python invocation" "$BAD_PY"; fi
 
-# shellcheck disable=SC2086
-BAD_TMP="$(grep -nE '(^|[^[:alnum:]_$"{/-])/tmp/' $RUNTIME_FILES 2>/dev/null | grep -v '^[^:]*:[0-9]*:[[:space:]]*#' || true)"
+BAD_TMP="$(grep -nE '(^|[^[:alnum:]_$"{/-])/tmp/' "${RUNTIME_FILES[@]}" 2>/dev/null | grep -v '^[^:]*:[0-9]*:[[:space:]]*#' || true)"
 if [ -z "$BAD_TMP" ]; then ok "no hardcoded /tmp path"; else bad "no hardcoded /tmp path" "$BAD_TMP"; fi
+
+# Every path built from a CLAUDE_* variable has to go through the conversion. The user
+# sets those, so on Windows they arrive in whatever spelling the user typed. Miss one
+# and the failure is silent: a read that finds nothing, or a write that lands somewhere
+# the reader never looks. Two were missed on the first pass (install.sh skipped the
+# re-pricing on update, and the card stamped its month where the status line could not
+# see it), which is what this guard exists to prevent from recurring.
+RAW_ENV="$(grep -nE '^[[:space:]]*[A-Z_]+="\$\{?CLAUDE_(CONFIG_DIR|CARBON_DB|CARBON_DIR|PLUGIN_ROOT)' "${RUNTIME_FILES[@]}" 2>/dev/null || true)"
+if [ -z "$RAW_ENV" ]; then
+  ok "every CLAUDE_* path assignment is converted"
+else
+  bad "every CLAUDE_* path assignment is converted" "$RAW_ENV"
+fi
 
 # ── 5. Line endings ──────────────────────────────────────────────────────────
 # Git for Windows clones with core.autocrlf=true, which would rewrite every script


### PR DESCRIPTION
Follow-up sweep on #28.

## Two paths missed

Both silent on Windows, which is why this needs a guard rather than a review.

- `install.sh` built the database path from `CLAUDE_CARBON_DB` without converting it. A user who set it to a native path got the post-update re-pricing skipped: `[ -f ]` found nothing and the step was passed over without a word.
- `generate-report.sh` stamped `last-card-month` under an unconverted `CLAUDE_CONFIG_DIR`, while the status line reads that stamp through the converted one. The card wrote where the reader could not look, so the monthly share nudge never cleared.

`tests/run-portability-tests.sh` now asserts that every `VAR="${CLAUDE_*"` assignment in a file that runs on a user's machine goes through the conversion. Verified it fails against the pre-fix tree and passes after.

## The guard could not have caught them

Writing it exposed a worse problem in the suite. The runtime file list was a space-joined string expanded unquoted, so on a checkout under a directory whose name contains a space (`~/Claude OS/code/claude-carbon`) it split into filenames that do not exist. grep read nothing, and the `bc`, `python3` and `/tmp` guards from #28 had been reporting `ok` while checking zero files. They passed on CI only because the runner path has no spaces.

The list is now an array expanded quoted, with two positive controls: the file count, and a token known to be present. A guard that cannot fail is worse than no guard.